### PR TITLE
Allowing to add plan to monthly billing

### DIFF
--- a/src/Application/MonthlyBillings/Commands/AddIncome/AddIncomeCommandHandler.cs
+++ b/src/Application/MonthlyBillings/Commands/AddIncome/AddIncomeCommandHandler.cs
@@ -35,7 +35,7 @@ public sealed class AddIncomeCommandHandler : ICommandHandler<AddIncomeCommand>
             command.Include
         );
 
-        monthlyBilling.AddIncome(income);
+        monthlyBilling.AddIncome(income);   // TODO: Pass values here
 
         await _dbContext.SaveChangesAsync(cancellationToken);
     }

--- a/src/Application/MonthlyBillings/Commands/AddPlan/AddPlanCommand.cs
+++ b/src/Application/MonthlyBillings/Commands/AddPlan/AddPlanCommand.cs
@@ -1,0 +1,12 @@
+using Application.Abstractions.CQRS;
+using Domain.MonthlyBillings;
+
+namespace Application.MonthlyBillings.Commands.AddPlan;
+
+public sealed record AddPlanCommand(
+    Guid MonthlyBillingId,
+    string Category,
+    decimal MoneyAmount,
+    Currency Currency,
+    uint SortOrder
+) : ICommand;

--- a/src/Application/MonthlyBillings/Commands/AddPlan/AddPlanCommandHandler.cs
+++ b/src/Application/MonthlyBillings/Commands/AddPlan/AddPlanCommandHandler.cs
@@ -1,0 +1,47 @@
+using Application.Abstractions.CQRS;
+using Application.Abstractions.Persistance;
+using Application.Exceptions;
+using Domain.Exceptions;
+using Domain.MonthlyBillings;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.MonthlyBillings.Commands.AddPlan;
+
+public sealed class AddPlanCommandHandler : ICommandHandler<AddPlanCommand>
+{
+    private readonly ISmugetDbContext _dbContext;
+
+    public AddPlanCommandHandler(ISmugetDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task HandleAsync(AddPlanCommand command, CancellationToken cancellationToken = default)
+    {
+        var monthlyBilling = await _dbContext.MonthlyBillings
+            .Include(m => m.Plans)
+            .FirstOrDefaultAsync(m => m.Id.Value == command.MonthlyBillingId);
+
+        if (monthlyBilling is null)
+        {
+            throw new MonthlyBillingNotFoundException();
+        }
+
+        if (monthlyBilling.State == State.Closed)
+        {
+            throw new MonthlyBillingAlreadyClosedException(
+                monthlyBilling.Month,
+                monthlyBilling.Year);
+        }
+
+        var plan = new Plan(
+            new Category(command.Category),
+            new Money(command.MoneyAmount, command.Currency),
+            command.SortOrder
+        );
+
+        monthlyBilling.AddPlan(plan);
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Domain/Exceptions/CategoryIsNullException.cs
+++ b/src/Domain/Exceptions/CategoryIsNullException.cs
@@ -1,0 +1,7 @@
+namespace Domain.Exceptions;
+
+public sealed class CategoryIsNullException : SmugetException
+{
+    public CategoryIsNullException()
+        : base("Category cannot be null or empty") { }
+}

--- a/src/Domain/Exceptions/InvalidPlanIdException.cs
+++ b/src/Domain/Exceptions/InvalidPlanIdException.cs
@@ -1,0 +1,7 @@
+namespace Domain.Exceptions;
+
+public sealed class InvalidPlanIdException : SmugetException
+{
+    public InvalidPlanIdException()
+        : base($"Plan id cannot be empty.") { }
+}

--- a/src/Domain/Exceptions/PlanIsNullException.cs
+++ b/src/Domain/Exceptions/PlanIsNullException.cs
@@ -1,0 +1,7 @@
+namespace Domain.Exceptions;
+
+public sealed class PlanIsNullException : SmugetException
+{
+    public PlanIsNullException()
+        : base("Plan cannot be empty!") { }
+}

--- a/src/Domain/MonthlyBillings/Category.cs
+++ b/src/Domain/MonthlyBillings/Category.cs
@@ -1,0 +1,21 @@
+using Domain.Exceptions;
+
+namespace Domain.MonthlyBillings;
+
+public sealed class Category
+{
+    private const byte MaxLengthForCategoryName = 20;
+    public string Value { get; }
+
+    public Category(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new CategoryIsNullException();    // TODO: Change name
+        }
+
+        Value = value;
+    }
+
+    private Category() { }
+}

--- a/src/Domain/MonthlyBillings/Income.cs
+++ b/src/Domain/MonthlyBillings/Income.cs
@@ -2,9 +2,9 @@ using Domain.Exceptions;
 
 namespace Domain.MonthlyBillings;
 
-public sealed class Income
+public sealed class Income // TODO: Make internal?
 {
-    public IncomeId Id { get; } = new IncomeId(Guid.NewGuid());
+    public IncomeId Id { get; } = new IncomeId(Guid.NewGuid()); // TODO: Remove identity from this class
     public Name Name { get; }
     public Money Money { get; }
     public bool Include { get; }

--- a/src/Domain/MonthlyBillings/MonthlyBilling.cs
+++ b/src/Domain/MonthlyBillings/MonthlyBilling.cs
@@ -7,16 +7,19 @@ public sealed class MonthlyBilling
     private MonthlyBilling() { }
 
     private readonly List<Income> _incomes = new();
+    private readonly List<Plan> _plans = new();
 
     public MonthlyBillingId Id { get; } = new MonthlyBillingId(Guid.NewGuid());
     public Year Year { get; }
     public Month Month { get; }
     public State State { get; private set; } = State.Open;
     public IReadOnlyCollection<Income> Incomes => _incomes.AsReadOnly();
+    public IReadOnlyCollection<Plan> Plans => _plans.AsReadOnly();
 
     public MonthlyBilling(
         Year year,
-        Month month)
+        Month month
+    )
     {
         if (year is null)
         {
@@ -46,6 +49,16 @@ public sealed class MonthlyBilling
         }
 
         _incomes.Add(income);
+    }
+
+    public void AddPlan(Plan plan)
+    {
+        if (plan is null)
+        {
+            throw new PlanIsNullException();
+        }
+
+        _plans.Add(plan);
     }
 
     public void Close()

--- a/src/Domain/MonthlyBillings/Plan.cs
+++ b/src/Domain/MonthlyBillings/Plan.cs
@@ -1,0 +1,35 @@
+using Domain.Exceptions;
+
+namespace Domain.MonthlyBillings;
+
+public sealed class Plan
+{
+    public PlanId Id { get; private set; } = new PlanId(Guid.NewGuid());
+    public Category Category { get; private set; }
+    public Money MoneyAmount { get; private set; }
+    public uint SortOrder { get; private set; }
+
+    public Plan(
+        Category category,
+        Money amount,
+        uint sortOrder
+    )
+    {
+        if (category is null)
+        {
+            throw new CategoryIsNullException();
+        }
+
+        Category = category;
+
+        if (amount is null)
+        {
+            throw new MoneyIsNullException();
+        }
+
+        MoneyAmount = amount;
+        SortOrder = sortOrder;
+    }
+
+    private Plan() { }
+}

--- a/src/Domain/MonthlyBillings/PlanId.cs
+++ b/src/Domain/MonthlyBillings/PlanId.cs
@@ -1,0 +1,22 @@
+using Domain.Exceptions;
+
+namespace Domain.MonthlyBillings;
+
+public sealed record PlanId
+{
+    public Guid Value { get; }
+
+    public PlanId(
+        Guid value
+    )
+    {
+        if (value == Guid.Empty)
+        {
+            throw new InvalidPlanIdException();
+        }
+
+        Value = value;
+    }
+
+    private PlanId() { }
+}

--- a/src/Infrastructure/Persistance/Configurations/IncomesConfiguration.cs
+++ b/src/Infrastructure/Persistance/Configurations/IncomesConfiguration.cs
@@ -9,28 +9,28 @@ internal sealed class IncomesConfiguration : IEntityTypeConfiguration<Income>
     public void Configure(EntityTypeBuilder<Income> builder)
     {
         builder
-            .HasKey(b => b.Id);
+            .HasKey(i => i.Id);
 
         builder
-            .Property(b => b.Id)
+            .Property(i => i.Id)
             .IsRequired()
             .HasConversion(
-                v => v.Value,
-                v => new(v));
+                id => id.Value,
+                value => new(value));
 
         builder
-            .Property(b => b.Name)
+            .Property(i => i.Name)
             .IsRequired()
             .HasMaxLength(50)
             .HasConversion(
-                v => v.Value,
-                v => new(v));
+                name => name.Value,
+                value => new(value));
 
         builder
-            .OwnsOne<Money>(m => m.Money);
+            .OwnsOne(i => i.Money);
 
         builder
-            .Property(b => b.Include)
+            .Property(i => i.Include)
             .IsRequired();
     }
 }

--- a/src/Infrastructure/Persistance/Configurations/PlansConfiguration.cs
+++ b/src/Infrastructure/Persistance/Configurations/PlansConfiguration.cs
@@ -1,0 +1,36 @@
+using Domain.MonthlyBillings;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.Persistance.Configurations;
+
+internal sealed class PlansConfiguration : IEntityTypeConfiguration<Plan>
+{
+    public void Configure(EntityTypeBuilder<Plan> builder)
+    {
+        builder
+            .HasKey(p => p.Id);
+
+        builder
+            .Property(p => p.Id)
+            .IsRequired()
+            .HasConversion(
+                id => id.Value,
+                value => new PlanId(value));
+
+        builder
+            .Property(p => p.Category)
+            .IsRequired()
+            .HasMaxLength(25)
+            .HasConversion(
+                category => category.Value,
+                value => new Category(value));
+
+        builder
+            .OwnsOne(p => p.MoneyAmount);
+
+        builder
+            .Property(p => p.SortOrder)
+            .IsRequired();
+    }
+}

--- a/src/Requests/MonthlyBillings/AddIncome.http
+++ b/src/Requests/MonthlyBillings/AddIncome.http
@@ -1,0 +1,13 @@
+@host = https://localhost:7188
+
+@id = 623ade79-d27f-47b3-b175-62737d5e3e8f
+
+POST {{host}}/api/monthlyBillings/{{id}}/incomes
+Content-Type: application/json
+
+{
+    "name": "Earn",
+    "moneyAmount": 1500.09,
+    "currency": 1,
+    "includeInBilling": true
+}

--- a/src/Requests/MonthlyBillings/AddPlan.http
+++ b/src/Requests/MonthlyBillings/AddPlan.http
@@ -1,0 +1,13 @@
+@host = https://localhost:7188
+
+@id = 9c74571b-08e9-486b-8dd2-bb7ca53bc069
+
+POST {{host}}/api/monthlyBillings/{{id}}/plans
+Content-Type: application/json
+
+{
+    "category": "Fuel",
+    "moneyAmount": 1500.09,
+    "currency": 1,
+    "sortOrder": 1
+}

--- a/src/Requests/MonthlyBillings/Open.http
+++ b/src/Requests/MonthlyBillings/Open.http
@@ -1,0 +1,9 @@
+@host = https://localhost:7188
+
+POST {{host}}/api/monthlyBillings
+Content-Type: application/json
+
+{
+    "Year": 2023,
+    "Month": 4
+}

--- a/src/WebAPI/MonthlyBillings/AddIncomeRequest.cs
+++ b/src/WebAPI/MonthlyBillings/AddIncomeRequest.cs
@@ -1,5 +1,4 @@
 using Domain.MonthlyBillings;
-using Microsoft.AspNetCore.Mvc;
 
 namespace WebAPI.MonthlyBillings;
 

--- a/src/WebAPI/MonthlyBillings/AddPlanRequest.cs
+++ b/src/WebAPI/MonthlyBillings/AddPlanRequest.cs
@@ -1,0 +1,10 @@
+using Domain.MonthlyBillings;
+
+namespace WebAPI.MonthlyBillings;
+
+public sealed record AddPlanRequest(
+    string Category,
+    decimal Money,
+    Currency Currency,
+    uint SortOrder
+);

--- a/src/WebAPI/MonthlyBillings/MonthlyBillingsController.cs
+++ b/src/WebAPI/MonthlyBillings/MonthlyBillingsController.cs
@@ -1,6 +1,8 @@
 using Application.Abstractions.CQRS;
 using Application.MonthlyBillings.Commands.AddIncome;
+using Application.MonthlyBillings.Commands.AddPlan;
 using Application.MonthlyBillings.Commands.OpenMonthlyBilling;
+using Domain.MonthlyBillings;
 using Microsoft.AspNetCore.Mvc;
 
 namespace WebAPI.MonthlyBillings;
@@ -11,14 +13,17 @@ public sealed class MonthlyBillingsController : ControllerBase
 {
     private readonly ICommandHandler<OpenMonthlyBillingCommand> _openMonthlyBilling;
     private readonly ICommandHandler<AddIncomeCommand> _addIncome;
+    private readonly ICommandHandler<AddPlanCommand> _addPlan;
 
     public MonthlyBillingsController(
         ICommandHandler<OpenMonthlyBillingCommand> openMonthlyBilling,
-        ICommandHandler<AddIncomeCommand> addIncome
+        ICommandHandler<AddIncomeCommand> addIncome,
+        ICommandHandler<AddPlanCommand> addPlan
     )
     {
         _openMonthlyBilling = openMonthlyBilling;
         _addIncome = addIncome;
+        _addPlan = addPlan;
     }
 
     [HttpPost]
@@ -51,6 +56,27 @@ public sealed class MonthlyBillingsController : ControllerBase
                 amount,
                 currency,
                 include),
+            token);
+
+        return Created("", null);
+    }
+
+    [HttpPost("{id}/plans")]
+    public async Task<IActionResult> AddPlan(
+        [FromRoute(Name = "id")] Guid monthlyBillingId,
+        [FromBody] AddPlanRequest request,
+        CancellationToken token = default
+    )
+    {
+        var (category, amount, currency, sortOrder) = request;
+
+        await _addPlan.HandleAsync(
+            new AddPlanCommand(
+                monthlyBillingId,
+                category,
+                amount,
+                currency,
+                sortOrder),
             token);
 
         return Created("", null);

--- a/tests/Domain.Unit.Tests/MonthlyBillings/IncomeTests.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/IncomeTests.cs
@@ -1,4 +1,3 @@
-using System;
 using Domain.Exceptions;
 using Domain.MonthlyBillings;
 

--- a/tests/Domain.Unit.Tests/MonthlyBillings/MonthlyBillingTests.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/MonthlyBillingTests.cs
@@ -137,6 +137,54 @@ public sealed class MonthlyBillingTests
     }
 
     [Fact]
+    public void AddPlan_WhenPassedProperData_ShouldAddPlanToMonthlyBilling()
+    {
+        // Arrange
+        var cut = new MonthlyBilling(
+            new Year(2023),
+            new Month(4));
+
+        var plan = new Plan(
+            new Category("Fuel"),
+            new Money(156.84M, Currency.PLN),
+            1
+        );
+
+        // Act
+        cut.AddPlan(plan);
+
+        // Assert
+        cut.Plans.Should().HaveCount(1);
+        cut.Plans.Should().BeEquivalentTo(
+            new List<Plan>()
+            {
+                new Plan(
+                    new Category("Fuel"),
+                    new Money(156.84M, Currency.PLN),
+                    1u
+                )
+            }.AsReadOnly(),
+        c => c.Excluding(e => e.Id));
+    }
+
+    [Fact]
+    public async void AddPlan_WhenPlanIsNull_ShouldThrowPlanIsNullException()
+    {
+        // Arrange
+        var cut = new MonthlyBilling(
+            new Year(2023),
+            new Month(2)
+        );
+
+        Plan plan = null;
+
+        var addPlan = () => cut.AddPlan(plan);
+
+        // Act & Assert
+        Assert.Throws<PlanIsNullException>(addPlan);
+    }
+
+    [Fact]
     public void Close_WhenCalled_ShouldChangeState()
     {
         // Arrange

--- a/tests/Domain.Unit.Tests/MonthlyBillings/PlanTests.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/PlanTests.cs
@@ -1,0 +1,61 @@
+using Domain.Exceptions;
+using Domain.MonthlyBillings;
+
+namespace Domain.Unit.Tests.MonthlyBillings;
+
+public sealed class PlanTest
+{
+    [Fact]
+    public void Plan_WhenPassedProperData_ShouldReturnExpectedObject()
+    {
+        // Arrange
+        Category category = new("Fuel");
+        Money money = new Money(525.88m, Currency.PLN);
+        uint sortOrder = 1u;
+
+        var createPlan = () => new Plan(
+            category,
+            money,
+            sortOrder
+        );
+
+        // Act
+        var result = createPlan();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().Match<Plan>(
+            p => p.Category == category
+            && p.MoneyAmount.Equals(money)
+            && p.SortOrder == sortOrder
+        );
+    }
+
+    [Fact]
+    public void Plan_WhenPassedNullCategory_ShouldThrowCategoryIsNullException()
+    {
+        // Arrange
+        var createPlan = () => new Plan(
+            null,
+            new Money(21m, Currency.USD),
+            1u
+        );
+
+        // Act & Assert
+        Assert.Throws<CategoryIsNullException>(createPlan);
+    }
+
+    [Fact]
+    public void Plan_WhenPassedNullMoney_ShouldThrowMoneyIsNullException()
+    {
+        // Arrange
+        var createPlan = () => new Plan(
+            new Category("Shopping"),
+            null,
+            1u
+        );
+
+        // Act & Assert
+        Assert.Throws<MoneyIsNullException>(createPlan);
+    }
+}

--- a/tests/Domain.Unit.Tests/MonthlyBillings/ValueObjects/CategoryTests.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/ValueObjects/CategoryTests.cs
@@ -1,0 +1,34 @@
+using Domain.Exceptions;
+using Domain.MonthlyBillings;
+
+namespace Domain.Unit.Tests.MonthlyBillings.ValueObjects;
+
+public sealed class CategoryTests
+{
+    [Fact]
+    public void Category_WhenPassedValidData_ShouldReturnExpectedObject()
+    {
+        // Arrange
+        var createCategory = () => new Category("Fuel");
+
+        // Act
+        var result = createCategory();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Value.Should().Be("Fuel");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public void Category_WhenPassedNullOrWhiteSpaceCategory_ShouldThrowCategoryIsNullException(string value)
+    {
+        // Arrange
+        var createCategory = () => new Category(value);
+
+        // Act & Assert
+        Assert.Throws<CategoryIsNullException>(createCategory);
+    }
+}

--- a/tests/Domain.Unit.Tests/MonthlyBillings/ValueObjects/IncomeIdTests.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/ValueObjects/IncomeIdTests.cs
@@ -7,7 +7,7 @@ namespace Domain.Unit.Tests.MonthlyBillings.ValueObjects;
 public sealed class IncomeIdTests
 {
     [Fact]
-    public void IncomeId_WhenPassedPRoperData_ShouldReturnExpectedObject()
+    public void IncomeId_WhenPassedProperData_ShouldReturnExpectedObject()
     {
         // Arrange
         Guid guid = Guid.NewGuid();

--- a/tests/Domain.Unit.Tests/MonthlyBillings/ValueObjects/PlanIdTests.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/ValueObjects/PlanIdTests.cs
@@ -1,0 +1,34 @@
+using System;
+using Domain.Exceptions;
+using Domain.MonthlyBillings;
+
+namespace Domain.Unit.Tests.MonthlyBillings.ValueObjects;
+
+public sealed class PlanIdTests
+{
+    [Fact]
+    public void PlanId_WhenPassedProperData_ShouldReturnExpectedObject()
+    {
+        // Arrange
+        Guid guid = Guid.NewGuid();
+        var createPlanId = () => new PlanId(guid);
+
+        // Act
+        var result = createPlanId();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().Match<PlanId>(
+            i => i.Value == guid);
+    }
+
+    [Fact]
+    public void PlanId_WhenPassedEmptyGuid_ShouldThrowInvalidPlanIdException()
+    {
+        // Arrange
+        var createPlanId = () => new PlanId(Guid.Empty);
+
+        // Act & Assert
+        Assert.Throws<InvalidPlanIdException>(createPlanId);
+    }
+}


### PR DESCRIPTION
### What?

Added resource for adding plans to monthly biling period with route:

```java
[POST] /api/monthyBillings/{id}/plans
```

This resource has one route parameter id. It is the id of the monthly billing.

It also accepts body:

```json
{
    "category": "string",
    "moneyAmount": 0.0,
    "currency": 0,
    "sortOrder": 0
}
```

### Why?

The resource allows you to add plans to your monthly billing. It searches for existing monthly billingwith given id and add plan to it, if the plan is valid (not null values).

### How?

I've added new action `AddPlan` in `MonthlyBillingsController`. This action invokes `AddPlanCommandHandler`, which is responsible for getting monthly billing by passed id. If the monthly billing wasn't found, then the exception is throws MonthlyBillingNotFoundException. Otherwise, `AddPlan()` method is called and there all checks are done. When everything is valid, plan is added to the monthly billing.

Example request for adding plan to monthly billing for 4/2022:

```java
[POST] /api/monthlyBillings/270ad389-8a3a-4b78-91a8-bd30f6834d30/plans
```

with body:

```json
{
    "category": "Groceries",
    "moneyAmount": 250.75,
    "currency": 0,
    "sortOrder": 2
}
```

When succeded API will return `Created 201`.

#### Additional informations

- added unit tests for controler's action,
- added unit tests for domain object (e.g. Plan, PlanId and other),

#### What to improve?
- Implement repository pattern and move out dependency to `EntityFrameworkCore` from `Application` layer to `Infrastructure` layer. Add separate layer for persistance models (entities).

Related to #9 