### PR TITLE
#14 Refactor - currency enum

### DIFF
--- a/requests/MonthlyBillings/AddExpense.http
+++ b/requests/MonthlyBillings/AddExpense.http
@@ -1,14 +1,14 @@
 @host = https://localhost:7188
 
-@monthlyBillingId = 4bcfbe2e-0a4b-4c3a-ba27-cfba56c0a319
-@planId = 13abd720-e833-4692-aee0-1c4e44b76e29
+@monthlyBillingId = 1a1ad0cf-84ca-4c4b-b487-0c04922d820a
+@planId = 47ea3a25-4349-4dd8-98c5-b9b2aa91ea96
 
 POST {{host}}/api/monthlyBillings/{{monthlyBillingId}}/plans/{{planId}}/expenses
 Content-Type: application/json
 
 {
-    "money": 292.82,
-    "currency": 1,
+    "money": 125.78,
+    "currency": "EUR",
     "expenseDate": "2019-07-26T00:00:00+02:00",
-    "description": "Electricity"
+    "description": "Table"
 }

--- a/requests/MonthlyBillings/AddExpense.http
+++ b/requests/MonthlyBillings/AddExpense.http
@@ -1,14 +1,14 @@
 @host = https://localhost:7188
 
-@monthlyBillingId = 1a1ad0cf-84ca-4c4b-b487-0c04922d820a
-@planId = 47ea3a25-4349-4dd8-98c5-b9b2aa91ea96
+@monthlyBillingId = 141f01bb-f33d-4ce6-9a0e-11a7e92333b1
+@planId = 742400f4-ff34-4030-b6ec-1d0fb49e7c2f
 
 POST {{host}}/api/monthlyBillings/{{monthlyBillingId}}/plans/{{planId}}/expenses
 Content-Type: application/json
 
 {
     "money": 125.78,
-    "currency": "EUR",
+    "currency": "PLN",
     "expenseDate": "2019-07-26T00:00:00+02:00",
     "description": "Table"
 }

--- a/requests/MonthlyBillings/AddIncome.http
+++ b/requests/MonthlyBillings/AddIncome.http
@@ -1,13 +1,13 @@
 @host = https://localhost:7188
 
-@id = 4bcfbe2e-0a4b-4c3a-ba27-cfba56c0a319
+@id = 1a1ad0cf-84ca-4c4b-b487-0c04922d820a
 
 POST {{host}}/api/monthlyBillings/{{id}}/incomes
 Content-Type: application/json
 
 {
     "name": "Earn",
-    "moneyAmount": 5247.43,
-    "currency": 1,
+    "moneyAmount": 2341.97,
+    "currency": "EUR",
     "includeInBilling": true
 }

--- a/requests/MonthlyBillings/AddIncome.http
+++ b/requests/MonthlyBillings/AddIncome.http
@@ -1,6 +1,6 @@
 @host = https://localhost:7188
 
-@id = 1a1ad0cf-84ca-4c4b-b487-0c04922d820a
+@id = 141f01bb-f33d-4ce6-9a0e-11a7e92333b1
 
 POST {{host}}/api/monthlyBillings/{{id}}/incomes
 Content-Type: application/json
@@ -8,6 +8,6 @@ Content-Type: application/json
 {
     "name": "Earn",
     "moneyAmount": 2341.97,
-    "currency": "EUR",
+    "currency": "PLN",
     "includeInBilling": true
 }

--- a/requests/MonthlyBillings/AddPlan.http
+++ b/requests/MonthlyBillings/AddPlan.http
@@ -1,6 +1,6 @@
 @host = https://localhost:7188
 
-@id = 1a1ad0cf-84ca-4c4b-b487-0c04922d820a
+@id = 141f01bb-f33d-4ce6-9a0e-11a7e92333b1
 
 POST {{host}}/api/monthlyBillings/{{id}}/plans
 Content-Type: application/json

--- a/requests/MonthlyBillings/AddPlan.http
+++ b/requests/MonthlyBillings/AddPlan.http
@@ -1,13 +1,13 @@
 @host = https://localhost:7188
 
-@id = 4bcfbe2e-0a4b-4c3a-ba27-cfba56c0a319
+@id = 1a1ad0cf-84ca-4c4b-b487-0c04922d820a
 
 POST {{host}}/api/monthlyBillings/{{id}}/plans
 Content-Type: application/json
 
 {
-    "category": "House",
-    "moneyAmount": 2000,
-    "currency": 1,
-    "sortOrder": 1
+    "category": "Medicines",
+    "money": 127,
+    "currency": "EUR",
+    "sortOrder": 2
 }

--- a/requests/MonthlyBillings/Open.http
+++ b/requests/MonthlyBillings/Open.http
@@ -5,5 +5,6 @@ Content-Type: application/json
 
 {
     "Year": 2023,
-    "Month": 4
+    "Month": 4,
+    "Currency": "PLN"
 }

--- a/src/Application/MonthlyBillings/Commands/AddExpense/AddExpenseCommand.cs
+++ b/src/Application/MonthlyBillings/Commands/AddExpense/AddExpenseCommand.cs
@@ -7,7 +7,7 @@ public sealed record AddExpenseCommand(
     Guid MonthlyBillingId,
     Guid PlanId,
     decimal Money,
-    Currency Currency,
+    string Currency,
     DateTimeOffset ExpenseDate,
     string Description
 ) : ICommand;

--- a/src/Application/MonthlyBillings/Commands/AddExpense/AddExpenseCommandHandler.cs
+++ b/src/Application/MonthlyBillings/Commands/AddExpense/AddExpenseCommandHandler.cs
@@ -32,14 +32,18 @@ public sealed class AddExpenseCommandHandler : ICommandHandler<AddExpenseCommand
         }
 
         var expense = new Expense(
-            new Money(command.Money, command.Currency),
+            new Money(
+                command.Money,
+                new Currency(command.Currency)
+            ),
             command.ExpenseDate,
             command.Description
         );
 
         monthlyBilling.AddExpense(
             new PlanId(command.PlanId),
-            expense);
+            expense
+        );
 
         await _dbContext.SaveChangesAsync(cancellationToken);
     }

--- a/src/Application/MonthlyBillings/Commands/AddIncome/AddIncomeCommand.cs
+++ b/src/Application/MonthlyBillings/Commands/AddIncome/AddIncomeCommand.cs
@@ -7,6 +7,6 @@ public sealed record AddIncomeCommand(
     Guid MonthlyBillingId,
     string Name,
     decimal Amount,
-    Currency Currency,
+    string Currency,
     bool Include
 ) : ICommand;

--- a/src/Application/MonthlyBillings/Commands/AddIncome/AddIncomeCommandHandler.cs
+++ b/src/Application/MonthlyBillings/Commands/AddIncome/AddIncomeCommandHandler.cs
@@ -32,11 +32,14 @@ public sealed class AddIncomeCommandHandler : ICommandHandler<AddIncomeCommand>
 
         var income = new Income(
             new Name(command.Name),
-            new Money(command.Amount, command.Currency),
+            new Money(
+                command.Amount,
+                new Currency(command.Currency)
+            ),
             command.Include
         );
 
-        monthlyBilling.AddIncome(income);   // TODO: Pass values here
+        monthlyBilling.AddIncome(income);
 
         await _dbContext.SaveChangesAsync(cancellationToken);
     }

--- a/src/Application/MonthlyBillings/Commands/AddPlan/AddPlanCommand.cs
+++ b/src/Application/MonthlyBillings/Commands/AddPlan/AddPlanCommand.cs
@@ -7,6 +7,6 @@ public sealed record AddPlanCommand(
     Guid MonthlyBillingId,
     string Category,
     decimal MoneyAmount,
-    Currency Currency,
+    string Currency,
     uint SortOrder
 ) : ICommand;

--- a/src/Application/MonthlyBillings/Commands/AddPlan/AddPlanCommandHandler.cs
+++ b/src/Application/MonthlyBillings/Commands/AddPlan/AddPlanCommandHandler.cs
@@ -33,11 +33,14 @@ public sealed class AddPlanCommandHandler : ICommandHandler<AddPlanCommand>
             throw new MonthlyBillingAlreadyClosedException(
                 monthlyBilling.Month,
                 monthlyBilling.Year);
-        }
+        }   // TODO: Move to domain layer
 
         var plan = new Plan(
             new Category(command.Category),
-            new Money(command.MoneyAmount, command.Currency),
+            new Money(
+                command.MoneyAmount,
+                new Currency(command.Currency)
+            ),
             command.SortOrder
         );
 

--- a/src/Application/MonthlyBillings/Commands/OpenMonthlyBilling/OpenMonthlyBillingCommand.cs
+++ b/src/Application/MonthlyBillings/Commands/OpenMonthlyBilling/OpenMonthlyBillingCommand.cs
@@ -4,4 +4,6 @@ namespace Application.MonthlyBillings.Commands.OpenMonthlyBilling;
 
 public sealed record OpenMonthlyBillingCommand(
     ushort Year,
-    byte Month) : ICommand;
+    byte Month,
+    string Currency
+) : ICommand;

--- a/src/Application/MonthlyBillings/Commands/OpenMonthlyBilling/OpenMonthlyBillingCommandHandler.cs
+++ b/src/Application/MonthlyBillings/Commands/OpenMonthlyBilling/OpenMonthlyBillingCommandHandler.cs
@@ -42,7 +42,9 @@ public sealed class OpenMonthlyBillingCommandHandler : ICommandHandler<OpenMonth
 
         await _dbContext.MonthlyBillings.AddAsync(
             monthlyBilling,
-            cancellationToken);
+            cancellationToken
+        );
+
         await _dbContext.SaveChangesAsync(cancellationToken);
     }
 }

--- a/src/Application/MonthlyBillings/Commands/OpenMonthlyBilling/OpenMonthlyBillingCommandHandler.cs
+++ b/src/Application/MonthlyBillings/Commands/OpenMonthlyBilling/OpenMonthlyBillingCommandHandler.cs
@@ -19,6 +19,7 @@ public sealed class OpenMonthlyBillingCommandHandler : ICommandHandler<OpenMonth
     {
         var year = new Year(command.Year);
         var month = new Month(command.Month);
+        var currency = new Currency(command.Currency);
 
         var existingMonthlyBilling = await _dbContext.MonthlyBillings.FirstOrDefaultAsync(
             m => m.Year == year
@@ -35,6 +36,7 @@ public sealed class OpenMonthlyBillingCommandHandler : ICommandHandler<OpenMonth
         var monthlyBilling = new MonthlyBilling(
             year,
             month,
+            currency,
             State.Open,
             null,
             null

--- a/src/Application/MonthlyBillings/Mappings/PlanMappings.cs
+++ b/src/Application/MonthlyBillings/Mappings/PlanMappings.cs
@@ -16,7 +16,7 @@ public static class PlanMappings
         {
             Id = domain.Id.Value.ToString(),
             Category = domain.Category.Value,
-            Money = domain.MoneyAmount.ToString(),
+            Money = domain.Money.ToString(),
             SortOrder = domain.SortOrder,
             Expenses = domain.Expenses
                 .Select(e => e.ToDTO())

--- a/src/Domain/Exceptions/CategoryIsNullException.cs
+++ b/src/Domain/Exceptions/CategoryIsNullException.cs
@@ -3,5 +3,5 @@ namespace Domain.Exceptions;
 public sealed class CategoryIsNullException : SmugetException
 {
     public CategoryIsNullException()
-        : base("Category cannot be null or empty") { }
+        : base("Category cannot be null or empty.") { }
 }

--- a/src/Domain/Exceptions/CurrencyIsNullException.cs
+++ b/src/Domain/Exceptions/CurrencyIsNullException.cs
@@ -1,0 +1,7 @@
+namespace Domain.Exceptions;
+
+public sealed class CurrencyIsNullException : SmugetException
+{
+    public CurrencyIsNullException()
+        : base("Currency cannot be null or empty.") { }
+}

--- a/src/Domain/Exceptions/ExpenseIsNullException.cs
+++ b/src/Domain/Exceptions/ExpenseIsNullException.cs
@@ -3,5 +3,5 @@ namespace Domain.Exceptions;
 public sealed class ExpenseIsNullException : SmugetException
 {
     public ExpenseIsNullException()
-        : base("Expense cannot be empty!") { }
+        : base("Expense cannot be empty.") { }
 }

--- a/src/Domain/Exceptions/IncomeIsNullException.cs
+++ b/src/Domain/Exceptions/IncomeIsNullException.cs
@@ -3,5 +3,5 @@ namespace Domain.Exceptions;
 public sealed class IncomeIsNullException : SmugetException
 {
     public IncomeIsNullException()
-        : base("Income cannot be empty!") { }
+        : base("Income cannot be empty.") { }
 }

--- a/src/Domain/Exceptions/InvalidCurrencyException.cs
+++ b/src/Domain/Exceptions/InvalidCurrencyException.cs
@@ -1,0 +1,14 @@
+namespace Domain.Exceptions;
+
+public sealed class InvalidCurrencyException : SmugetException
+{
+    public string Currency { get; }
+
+    public InvalidCurrencyException(
+        string currency
+    )
+        : base($"There is no currency like '{currency}' supported in application.")
+    {
+        Currency = currency;
+    }
+}

--- a/src/Domain/Exceptions/InvalidExpenseIdException.cs
+++ b/src/Domain/Exceptions/InvalidExpenseIdException.cs
@@ -3,5 +3,5 @@ namespace Domain.Exceptions;
 public sealed class InvalidExpenseIdException : SmugetException
 {
     public InvalidExpenseIdException()
-        : base("Expense id cannot be empty!") { }
+        : base("Expense id cannot be empty.") { }
 }

--- a/src/Domain/Exceptions/MonthlyBillingCurrencyMismatchException.cs
+++ b/src/Domain/Exceptions/MonthlyBillingCurrencyMismatchException.cs
@@ -1,0 +1,16 @@
+using Domain.MonthlyBillings;
+
+namespace Domain.Exceptions;
+
+public sealed class MonthlyBillingCurrencyMismatchException : SmugetException
+{
+    public Currency Currency { get; }
+
+    public MonthlyBillingCurrencyMismatchException(
+        Currency currency
+    )
+        : base($"The currency '{currency.Value}' doesn't match monthly billing's currency.")
+    {
+        Currency = currency;
+    }
+}

--- a/src/Domain/Exceptions/PlanIdIsNullException.cs
+++ b/src/Domain/Exceptions/PlanIdIsNullException.cs
@@ -3,5 +3,5 @@ namespace Domain.Exceptions;
 public sealed class PlanIdIsNullException : SmugetException
 {
     public PlanIdIsNullException()
-        : base("PlanId cannot be empty!") { }
+        : base("PlanId cannot be empty.") { }
 }

--- a/src/Domain/Exceptions/PlanIsNullException.cs
+++ b/src/Domain/Exceptions/PlanIsNullException.cs
@@ -3,5 +3,5 @@ namespace Domain.Exceptions;
 public sealed class PlanIsNullException : SmugetException
 {
     public PlanIsNullException()
-        : base("Plan cannot be empty!") { }
+        : base("Plan cannot be empty.") { }
 }

--- a/src/Domain/MonthlyBillings/Currency.cs
+++ b/src/Domain/MonthlyBillings/Currency.cs
@@ -1,8 +1,64 @@
+using Domain.Exceptions;
+
 namespace Domain.MonthlyBillings;
 
-public enum Currency
+public sealed class Currency
 {
-    PLN,
-    EUR,
-    USD
+    private readonly string[] _currencies = { "PLN", "USD", "EUR" };
+
+    public string Value { get; }
+
+    public Currency(
+        string value
+    )
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new CurrencyIsNullException();
+        }
+
+        if (!_currencies.Contains(value))
+        {
+            throw new InvalidCurrencyException(value);
+        }
+
+        Value = value;
+    }
+
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null || obj.GetType() != GetType())
+        {
+            return false;
+        }
+
+        return ((Currency)obj).Value == Value;
+    }
+
+    public override int GetHashCode()
+    {
+        return Value.GetHashCode();
+    }
+
+    public static bool operator ==(Currency left, Currency right)
+    {
+        return Equals(left, right);
+    }
+
+    public static bool operator !=(Currency left, Currency right)
+    {
+        return !Equals(left, right);
+    }
+
+    public bool Equals(Currency other)
+    {
+        return Equals((object?)other);
+    }
+
+    private Currency() { }
 }

--- a/src/Domain/MonthlyBillings/Money.cs
+++ b/src/Domain/MonthlyBillings/Money.cs
@@ -5,7 +5,6 @@ namespace Domain.MonthlyBillings;
 public sealed record Money
 {
     public decimal Amount { get; }
-    // TODO: Make currency own type - enum record
     public Currency Currency { get; }
 
     public Money(
@@ -45,5 +44,10 @@ public sealed record Money
 
         var difference = left.Amount - right.Amount;
         return new Money(difference, left.Currency);
+    }
+
+    public override string ToString()
+    {
+        return $"{Amount :#.00} {Currency}";
     }
 }

--- a/src/Domain/MonthlyBillings/Plan.cs
+++ b/src/Domain/MonthlyBillings/Plan.cs
@@ -6,17 +6,17 @@ namespace Domain.MonthlyBillings;
 
 public sealed class Plan
 {
-    public PlanId Id { get; private set; } = new PlanId(Guid.NewGuid());
-    public Category Category { get; private set; }
-    public Money MoneyAmount { get; private set; }
-    public uint SortOrder { get; private set; }
+    public PlanId Id { get; } = new PlanId(Guid.NewGuid());
+    public Category Category { get; }
+    public Money Money { get; }
+    public uint SortOrder { get; }
     public IReadOnlyCollection<Expense> Expenses => _expenses.AsReadOnly();
 
-    private readonly List<Expense> _expenses = new List<Expense>();
+    private readonly List<Expense> _expenses = new();
 
     public Plan(
         Category category,
-        Money amount,
+        Money money,
         uint sortOrder
     )
     {
@@ -27,12 +27,12 @@ public sealed class Plan
 
         Category = category;
 
-        if (amount is null)
+        if (money is null)
         {
             throw new MoneyIsNullException();
         }
 
-        MoneyAmount = amount;
+        Money = money;
         SortOrder = sortOrder;
     }
 

--- a/src/Infrastructure/Persistance/Configurations/ExpensesConfiguration.cs
+++ b/src/Infrastructure/Persistance/Configurations/ExpensesConfiguration.cs
@@ -19,7 +19,18 @@ internal sealed class ExpensesConfiguration : IEntityTypeConfiguration<Expense>
                 value => new ExpenseId(value));
 
         builder
-            .OwnsOne(e => e.Money);
+            .OwnsOne(e => e.Money)
+            .Property(m => m.Amount)
+            .IsRequired();
+
+        builder
+            .OwnsOne(e => e.Money)
+            .Property(m => m.Currency)
+            .HasConversion(
+                currency => currency.Value,
+                value => new(value)
+            )
+            .IsRequired();
 
         builder
             .Property(e => e.Descritpion)

--- a/src/Infrastructure/Persistance/Configurations/IncomesConfiguration.cs
+++ b/src/Infrastructure/Persistance/Configurations/IncomesConfiguration.cs
@@ -27,7 +27,18 @@ internal sealed class IncomesConfiguration : IEntityTypeConfiguration<Income>
                 value => new(value));
 
         builder
-            .OwnsOne(i => i.Money);
+            .OwnsOne(i => i.Money)
+            .Property(m => m.Amount)
+            .IsRequired();
+
+        builder
+            .OwnsOne(i => i.Money)
+            .Property(m => m.Currency)
+            .HasConversion(
+                currency => currency.Value,
+                value => new(value)
+            )
+            .IsRequired();
 
         builder
             .Property(i => i.Include)

--- a/src/Infrastructure/Persistance/Configurations/MonthlyBillingsConfirguration.cs
+++ b/src/Infrastructure/Persistance/Configurations/MonthlyBillingsConfirguration.cs
@@ -31,5 +31,12 @@ internal sealed class MonthlyBillingsConfiguration : IEntityTypeConfiguration<Mo
             .HasConversion(
                 v => v.Value,
                 v => new(v));
+
+        builder
+            .Property(b => b.Currency)
+            .IsRequired()
+            .HasConversion(
+                v => v.Value,
+                v => new(v));
     }
 }

--- a/src/Infrastructure/Persistance/Configurations/PlansConfiguration.cs
+++ b/src/Infrastructure/Persistance/Configurations/PlansConfiguration.cs
@@ -27,7 +27,18 @@ internal sealed class PlansConfiguration : IEntityTypeConfiguration<Plan>
                 value => new Category(value));
 
         builder
-            .OwnsOne(p => p.MoneyAmount);
+            .OwnsOne(p => p.Money)
+            .Property(m => m.Amount)
+            .IsRequired();
+
+        builder
+            .OwnsOne(p => p.Money)
+            .Property(m => m.Currency)
+            .HasConversion(
+                currency => currency.Value,
+                value => new(value)
+            )
+            .IsRequired();
 
         builder
             .Property(p => p.SortOrder)

--- a/src/WebAPI/MonthlyBillings/AddExpenseRequest.cs
+++ b/src/WebAPI/MonthlyBillings/AddExpenseRequest.cs
@@ -4,7 +4,7 @@ namespace WebAPI.MonthlyBillings;
 
 public sealed record AddExpenseRequest(
     decimal Money,
-    Currency Currency,
+    string Currency,
     DateTimeOffset ExpenseDate,
     string Description
 );

--- a/src/WebAPI/MonthlyBillings/AddIncomeRequest.cs
+++ b/src/WebAPI/MonthlyBillings/AddIncomeRequest.cs
@@ -1,9 +1,7 @@
-using Domain.MonthlyBillings;
-
 namespace WebAPI.MonthlyBillings;
 
 public sealed record AddIncomeRequest(
     string Name,
     decimal MoneyAmount,
-    Currency Currency,
+    string Currency,
     bool IncludeInBilling = true);

--- a/src/WebAPI/MonthlyBillings/AddPlanRequest.cs
+++ b/src/WebAPI/MonthlyBillings/AddPlanRequest.cs
@@ -5,6 +5,6 @@ namespace WebAPI.MonthlyBillings;
 public sealed record AddPlanRequest(
     string Category,
     decimal Money,
-    Currency Currency,
+    string Currency,
     uint SortOrder
 );

--- a/src/WebAPI/MonthlyBillings/MonthlyBillingsController.cs
+++ b/src/WebAPI/MonthlyBillings/MonthlyBillingsController.cs
@@ -39,11 +39,16 @@ public sealed class MonthlyBillingsController : ControllerBase
         OpenMonthlyBillingRequest request,
         CancellationToken token = default)
     {
-        var (year, month) = request;
+        var (year, month, currency) = request;
 
         await _openMonthlyBilling.HandleAsync(
-            new OpenMonthlyBillingCommand(year, month),
-            token);
+            new OpenMonthlyBillingCommand(
+                year,
+                month,
+                currency
+            ),
+            token
+        );
 
         return Created("", null);
     }

--- a/src/WebAPI/MonthlyBillings/OpenMonthlyBillingRequest.cs
+++ b/src/WebAPI/MonthlyBillings/OpenMonthlyBillingRequest.cs
@@ -2,4 +2,6 @@ namespace WebAPI.MonthlyBillings;
 
 public sealed record OpenMonthlyBillingRequest(
     ushort Year,
-    byte Month);
+    byte Month,
+    string Currency
+);

--- a/src/WebAPI/WebAPI.csproj
+++ b/src/WebAPI/WebAPI.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.7">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>
 

--- a/tests/Domain.Unit.Tests/MonthlyBillings/ExpenseTests.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/ExpenseTests.cs
@@ -11,7 +11,7 @@ public sealed class ExpenseTests
     {
         // Arrange
         var createExpense = () => new Expense(
-            new Money(172.04M, Currency.EUR),
+            new Money(172.04M, new Currency("EUR")),
             new DateTimeOffset(new DateTime(2020, 9, 21)),
             "Breaks"
         );
@@ -29,7 +29,7 @@ public sealed class ExpenseTests
             .Match<Expense>(
                 e => e.Descritpion == "Breaks"
                 && e.ExpenseDate == new DateTimeOffset(new DateTime(2020, 9, 21))
-                && e.Money == new Money(172.04M, Currency.EUR)
+                && e.Money == new Money(172.04M, new Currency("EUR"))
             );
     }
 

--- a/tests/Domain.Unit.Tests/MonthlyBillings/IncomeTests.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/IncomeTests.cs
@@ -10,7 +10,7 @@ public sealed class IncomeTests
     {
         // Arrange
         Name name = new("Test name");
-        Money money = new Money(525.88m, Currency.PLN);
+        Money money = new Money(525.88m, new Currency("PLN"));
         var include = true;
 
         var createIncome = () => new Income(
@@ -37,7 +37,7 @@ public sealed class IncomeTests
         // Arrange
         var createIncome = () => new Income(
             null,
-            new Money(21m, Currency.USD),
+            new Money(21m, new Currency("USD")),
             true
         );
 

--- a/tests/Domain.Unit.Tests/MonthlyBillings/MonthlyBillingTests.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/MonthlyBillingTests.cs
@@ -67,12 +67,16 @@ public sealed class MonthlyBillingTests
     public void AddIncome_WhenPassedProperData_ShouldAddIncomeToMonthlyBilling()
     {
         // Arrange
-        var cut = MonthlyBillingUtilities.CreateMonthlyBilling();
+        var cut = new MonthlyBilling(
+            Constants.MonthlyBilling.Year,
+            Constants.MonthlyBilling.Month,
+            Constants.MonthlyBilling.State
+        );
 
         // Act
         cut.AddIncome(new Income(
             new Name("TEST"),
-            new Money(10m, Currency.PLN),
+            new Money(10m, new Currency("PLN")),
             true
         ));
 
@@ -83,7 +87,7 @@ public sealed class MonthlyBillingTests
             {
                 new Income(
                     new Name("TEST"),
-                    new Money(10m, Currency.PLN),
+                    new Money(10m, new Currency("PLN")),
                     true
                 )
             }.AsReadOnly(),
@@ -134,7 +138,7 @@ public sealed class MonthlyBillingTests
 
         var plan = new Plan(
             new Category("Fuel"),
-            new Money(156.84M, Currency.PLN),
+            new Money(156.84M, new Currency("PLN")),
             1
         );
 
@@ -148,7 +152,7 @@ public sealed class MonthlyBillingTests
             {
                 new Plan(
                     new Category("Fuel"),
-                    new Money(156.84M, Currency.PLN),
+                    new Money(156.84M, new Currency("PLN")),
                     1u
                 )
             }.AsReadOnly(),
@@ -204,7 +208,7 @@ public sealed class MonthlyBillingTests
         var cut = MonthlyBillingUtilities.CreateMonthlyBilling();
 
         Expense expense = new Expense(
-            new Money(125.0M, Currency.PLN),
+            new Money(125.0M, new Currency("PLN")),
             new DateTimeOffset(new DateTime(2023, 3, 6)),
             "eBay"
         );

--- a/tests/Domain.Unit.Tests/MonthlyBillings/MonthlyBillingTests.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/MonthlyBillingTests.cs
@@ -25,6 +25,7 @@ public sealed class MonthlyBillingTests
         result.Should().Match<MonthlyBilling>(
               m => m.Year == new Year(2023)
               && m.Month == new Month(2)
+              && m.Currency == new Currency("PLN")
               && m.State == State.Open
         );
     }
@@ -37,6 +38,7 @@ public sealed class MonthlyBillingTests
             => new MonthlyBilling(
                 null,
                 new Month(3),
+                new Currency("PLN"),
                 State.Open,
                 null,
                 null
@@ -54,6 +56,7 @@ public sealed class MonthlyBillingTests
             => new MonthlyBilling(
                 new Year(2007),
                 null,
+                new Currency("PLN"),
                 State.Open,
                 null,
                 null
@@ -64,12 +67,31 @@ public sealed class MonthlyBillingTests
     }
 
     [Fact]
+    public void MonthlyBilling_WhenPassedNullCurrency_ShouldThrowCurrencyIsNullException()
+    {
+        // Arrange
+        var createMonthlyBilling = ()
+            => new MonthlyBilling(
+                new Year(2007),
+                new Month(3),
+                null,
+                State.Open,
+                null,
+                null
+            );
+
+        // Act & Assert
+        Assert.Throws<CurrencyIsNullException>(createMonthlyBilling);
+    }
+
+    [Fact]
     public void AddIncome_WhenPassedProperData_ShouldAddIncomeToMonthlyBilling()
     {
         // Arrange
         var cut = new MonthlyBilling(
             Constants.MonthlyBilling.Year,
             Constants.MonthlyBilling.Month,
+            Constants.MonthlyBilling.Currency,
             Constants.MonthlyBilling.State
         );
 
@@ -125,12 +147,39 @@ public sealed class MonthlyBillingTests
     }
 
     [Fact]
+    public void AddIncome_WhenTryingToAddIncomeWithOtherCurrency_ShouldThrowMonthlyBillingCurrencyMismatchException()
+    {
+        // Arrange
+        var cut = new MonthlyBilling(
+            Constants.MonthlyBilling.Year,
+            Constants.MonthlyBilling.Month,
+            Constants.MonthlyBilling.Currency,
+            Constants.MonthlyBilling.State
+        );
+
+        var addIncomeWithOtherCurrency = () => cut.AddIncome(
+            new Income(
+                Constants.Income.Name,
+                new Money(
+                    123.923M,
+                    new Currency("EUR")
+                ),
+                true
+            )
+        );
+
+        // Act & Assert
+        Assert.Throws<MonthlyBillingCurrencyMismatchException>(addIncomeWithOtherCurrency);
+    }
+
+    [Fact]
     public void AddPlan_WhenPassedProperData_ShouldAddPlanToMonthlyBilling()
     {
         // Arrange
         var cut = new MonthlyBilling(
             Constants.MonthlyBilling.Year,
             Constants.MonthlyBilling.Month,
+            Constants.MonthlyBilling.Currency,
             Constants.MonthlyBilling.State,
             null,
             null
@@ -171,6 +220,32 @@ public sealed class MonthlyBillingTests
 
         // Act & Assert
         Assert.Throws<PlanIsNullException>(addPlan);
+    }
+
+    [Fact]
+    public void AddPlan_WhenTryingToAddPlanWithOtherCurrency_ShouldThrowMonthlyBillingCurrencyMismatchException()
+    {
+        // Arrange
+        var cut = new MonthlyBilling(
+            Constants.MonthlyBilling.Year,
+            Constants.MonthlyBilling.Month,
+            Constants.MonthlyBilling.Currency,
+            Constants.MonthlyBilling.State
+        );
+
+        var addPlanWithOtherCurrency = () => cut.AddPlan(
+            new Plan(
+                Constants.Plan.Category,
+                new Money(
+                    842.10M,
+                    new Currency("USD")
+                ),
+                1
+            )
+        );
+
+        // Act & Assert
+        Assert.Throws<MonthlyBillingCurrencyMismatchException>(addPlanWithOtherCurrency);
     }
 
     [Fact]
@@ -217,6 +292,34 @@ public sealed class MonthlyBillingTests
 
         // Act & Assert
         Assert.Throws<PlanNotFoundException>(addExpense);
+    }
+
+    [Fact(Skip = "Requires domain constructors refactor (id).")]
+    public void AddExpense_WhenTryingToAddExpenseWithOtherCurrency_ShouldThrowMonthlyBillingCurrencyMismatchException()
+    {
+        // Arrange
+        var cut = new MonthlyBilling(
+            Constants.MonthlyBilling.Year,
+            Constants.MonthlyBilling.Month,
+            Constants.MonthlyBilling.Currency,
+            Constants.MonthlyBilling.State,
+            plans: MonthlyBillingUtilities.CreatePlans()
+        );
+
+        var addExpenseWithOtherCurrency = () => cut.AddExpense(
+            new PlanId(Guid.NewGuid()),
+            new Expense(
+                new Money(
+                    65.99M,
+                    new Currency("USD")
+                ),
+                Constants.Expense.ExpenseDate,
+                Constants.Expense.Descripiton
+            )
+        );
+
+        // Act & Assert
+        Assert.Throws<MonthlyBillingCurrencyMismatchException>(addExpenseWithOtherCurrency);
     }
 
     [Fact]

--- a/tests/Domain.Unit.Tests/MonthlyBillings/PlanTests.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/PlanTests.cs
@@ -12,7 +12,7 @@ public sealed class PlanTest
     {
         // Arrange
         Category category = new("Fuel");
-        Money money = new Money(525.88m, Currency.PLN);
+        Money money = new Money(525.88m, new Currency("PLN"));
         uint sortOrder = 1u;
 
         var createPlan = () => new Plan(
@@ -28,7 +28,7 @@ public sealed class PlanTest
         result.Should().NotBeNull();
         result.Should().Match<Plan>(
             p => p.Category == category
-            && p.MoneyAmount.Equals(money)
+            && p.Money.Equals(money)
             && p.SortOrder == sortOrder
         );
     }
@@ -39,7 +39,7 @@ public sealed class PlanTest
         // Arrange
         var createPlan = () => new Plan(
             null,
-            new Money(21m, Currency.USD),
+            new Money(21m, new Currency("USD")),
             1u
         );
 
@@ -67,12 +67,12 @@ public sealed class PlanTest
         // Arrange
         var cut = new Plan(
             new Category("Groceries"),
-            new Money(400M, Currency.USD),
+            new Money(400M, new Currency("USD")),
             1
         );
 
         var expense = new Expense(
-            new Money(150M, Currency.PLN),
+            new Money(150M, new Currency("PLN")),
             new DateTimeOffset(new DateTime(2020, 3, 4)),
             "Farmer's market"
         );
@@ -90,7 +90,7 @@ public sealed class PlanTest
         firstExpense
             .Should()
             .Match<Expense>(
-                e => e.Money == new Money(150M, Currency.PLN)
+                e => e.Money == new Money(150M, new Currency("PLN"))
                 && e.ExpenseDate == new DateTimeOffset(new DateTime(2020, 3, 4))
                 && e.Descritpion == "Farmer's market"
             );

--- a/tests/Domain.Unit.Tests/MonthlyBillings/TestUtilities/Constants.Expense.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/TestUtilities/Constants.Expense.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Domain.Unit.Tests.MonthlyBillings.TestUtilities;
+
+public static partial class Constants
+{
+    public static class Expense
+    {
+        public static readonly Guid Id = Guid.NewGuid();
+        public static readonly DateTimeOffset ExpenseDate = new(new DateTime(2023, 6, 15));
+        public const string Descripiton = "Description";
+    }
+}

--- a/tests/Domain.Unit.Tests/MonthlyBillings/TestUtilities/Constants.Income.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/TestUtilities/Constants.Income.cs
@@ -7,7 +7,7 @@ public static partial class Constants
     public static class Income
     {
         public static readonly Name Name = new("Name");
-        public static readonly Money Money = new(11.75M, Currency.PLN);
+        public static readonly Money Money = new(11.75M, new Currency("PLN"));
 
         public static Name NameFromIndex(int index)
             => new($"{Name} {index}");

--- a/tests/Domain.Unit.Tests/MonthlyBillings/TestUtilities/Constants.MonthlyBilling.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/TestUtilities/Constants.MonthlyBilling.cs
@@ -8,6 +8,7 @@ public static partial class Constants
     {
         public static readonly Year Year = new(2023);
         public static readonly Month Month = new(2);
+        public static readonly Currency Currency = new("PLN");
         public static readonly State State = State.Open;
     }
 }

--- a/tests/Domain.Unit.Tests/MonthlyBillings/TestUtilities/Constants.Plan.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/TestUtilities/Constants.Plan.cs
@@ -7,7 +7,7 @@ public static partial class Constants
     public static class Plan
     {
         public static readonly Category Category = new("Category");
-        public static readonly Money Money = new(12.5M, Currency.PLN);
+        public static readonly Money Money = new(12.5M, new Currency("PLN"));
 
         public static Category CategoryFromIndex(int index)
             => new($"{Category.Value} {index}");

--- a/tests/Domain.Unit.Tests/MonthlyBillings/TestUtilities/MonthlyBillingUtilities.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/TestUtilities/MonthlyBillingUtilities.cs
@@ -13,6 +13,7 @@ public static class MonthlyBillingUtilities
         => new(
             Constants.MonthlyBilling.Year,
             Constants.MonthlyBilling.Month,
+            Constants.MonthlyBilling.Currency,
             Constants.MonthlyBilling.State,
             plans ?? CreatePlans(),
             incomes ?? CreateIncomes()

--- a/tests/Domain.Unit.Tests/MonthlyBillings/ValueObjects/CurrencyTests.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/ValueObjects/CurrencyTests.cs
@@ -1,0 +1,120 @@
+using Domain.Exceptions;
+using Domain.MonthlyBillings;
+
+namespace Domain.Unit.Tests.MonthlyBillings.ValueObjects;
+
+public sealed class CurrencyTests
+{
+    [Fact]
+    public void Currency_WhenPassedValidData_ShouldReturnExpectedObject()
+    {
+        // Arrange
+        var createCurrency = () => new Currency("PLN");
+
+        // Act
+        var result = createCurrency();
+
+        // Assert
+        result
+            .Should()
+            .NotBeNull();
+
+        result
+            .Should()
+            .Match<Currency>(
+                c => c.Value == "PLN"
+            );
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public void Currency_WhenPassedNullOrWhiteSpaceString_ShouldThrowCurrencyIsNullException(string value)
+    {
+        // Arrange
+        var createCurrency = () => new Currency(value);
+
+        // Act & Assert
+        Assert.Throws<CurrencyIsNullException>(createCurrency);
+    }
+
+    [Theory]
+    [InlineData("ABC")]
+    [InlineData("123")]
+    [InlineData("AZB")]
+    public void Currency_WhenPassedInvalidString_ShouldThrowInvalidCurrencyException(string value)
+    {
+        // Arrange
+        var createCurrency = () => new Currency(value);
+
+        // Act & Assert
+        var exception = Assert.Throws<InvalidCurrencyException>(createCurrency);
+        exception.Currency
+            .Should()
+            .Be(value);
+    }
+
+    [Theory]
+    [InlineData("PLN", "PLN")]
+    [InlineData("USD", "USD")]
+    [InlineData("EUR", "EUR")]
+    public void Equals_WhenCalledForObjectWithSameValue_ShouldReturnTrue(
+        string value,
+        string otherValue
+    )
+    {
+        // Arrange
+        var cut = new Currency(value);
+
+        // Act
+        var result = cut.Equals(new Currency(otherValue));
+
+        // Assert
+        result
+            .Should()
+            .BeTrue();
+    }
+
+    [Theory]
+    [InlineData("PLN", "USD")]
+    [InlineData("USD", "EUR")]
+    [InlineData("EUR", "PLN")]
+    public void Equals_WhenCalledForObjectWithOtherValue_ShouldReturnFalse(
+        string value,
+        string otherValue
+    )
+    {
+        // Arrange
+        var cut = new Currency(value);
+
+        // Act
+        var result = cut.Equals(new Currency(otherValue));
+
+        // Assert
+        result
+            .Should()
+            .BeFalse();
+    }
+
+    [Theory]
+    [InlineData("PLN", "PLN")]
+    [InlineData("USD", "USD")]
+    [InlineData("EUR", "EUR")]
+    public void ToString_WhenCalled_ShouldReturnExpectedString(
+        string value,
+        string expectedString
+    )
+    {
+        // Arrange
+        var cut = new Currency(value);
+
+        // Act
+        var result = cut.ToString();
+
+        // Assert
+        result
+            .Should()
+            .BeEquivalentTo(expectedString);
+    }
+}

--- a/tests/Domain.Unit.Tests/MonthlyBillings/ValueObjects/MoneyTests.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/ValueObjects/MoneyTests.cs
@@ -11,7 +11,7 @@ public sealed class MoneyTests
         // Arrange
         var createMoney = () => new Money(
             15.06m,
-            Currency.PLN
+            new Currency("PLN")
         );
 
         // Act
@@ -21,7 +21,7 @@ public sealed class MoneyTests
         result.Should().NotBeNull();
         result.Should().Match<Money>(
             m => m.Amount == 15.06m
-            && m.Currency == Currency.PLN
+            && m.Currency == new Currency("PLN")
         );
     }
 
@@ -32,8 +32,8 @@ public sealed class MoneyTests
     public void AddOperator_WhenPassedTwoValues_ShouldAddThem(decimal a, decimal b, decimal expected)
     {
         // Arrange
-        var left = new Money(a, Currency.PLN);
-        var right = new Money(b, Currency.PLN);
+        var left = new Money(a, new Currency("PLN"));
+        var right = new Money(b, new Currency("PLN"));
 
         // Act
         var result = left + right;
@@ -50,8 +50,8 @@ public sealed class MoneyTests
     public void AddOperator_WhenPassedTwoValuesWithDifferentCurrencies_ShoudlThrowMoneyCurrencyMismatchException()
     {
         // Arrange
-        var left = new Money(15.06m, Currency.PLN);
-        var right = new Money(4.95m, Currency.EUR);
+        var left = new Money(15.06m, new Currency("PLN"));
+        var right = new Money(4.95m, new Currency("EUR"));
 
         var addMoney = () => left + right;
 
@@ -66,8 +66,8 @@ public sealed class MoneyTests
     public void MinusOperator_WhenPassedTwoValues_ShouldSubstractThem(decimal a, decimal b, decimal expected)
     {
         // Arrange
-        var left = new Money(a, Currency.EUR);
-        var right = new Money(b, Currency.EUR);
+        var left = new Money(a, new Currency("EUR"));
+        var right = new Money(b, new Currency("EUR"));
 
         // Act
         var result = left - right;
@@ -84,8 +84,8 @@ public sealed class MoneyTests
     public void MinusOperator_WhenPassedTwoValuesWithDifferentCurrencies_ShouldThrowMoneyCurrencyMismatchException()
     {
         // Arrange
-        var left = new Money(-21.07m, Currency.USD);
-        var right = new Money(13.85m, Currency.EUR);
+        var left = new Money(-21.07m, new Currency("USD"));
+        var right = new Money(13.85m, new Currency("EUR"));
 
         var substractMoney = () => left - right;
 
@@ -97,8 +97,8 @@ public sealed class MoneyTests
     public void Equals_WhenPassedObjectWithSameValue_ShouldReturnTrue()
     {
         // Arrange
-        var money = new Money(15.06m, Currency.PLN);
-        var equalTo = new Money(15.06m, Currency.PLN);
+        var money = new Money(15.06m, new Currency("PLN"));
+        var equalTo = new Money(15.06m, new Currency("PLN"));
 
         // Act
         var result = money.Equals(equalTo);
@@ -108,18 +108,43 @@ public sealed class MoneyTests
     }
 
     [Theory]
-    [InlineData(15.06, Currency.USD)]
-    [InlineData(-21.04, Currency.PLN)]
-    public void Equals_WhenPassedObjectWithOtherValue_ShouldReturnFalse(decimal amount, Currency currency)
+    [InlineData(15.06, "USD")]
+    [InlineData(-21.04, "PLN")]
+    public void Equals_WhenPassedObjectWithOtherValue_ShouldReturnFalse(decimal amount, string currency)
     {
         // Arrange
-        var money = new Money(15.06m, Currency.PLN);
-        var equalTo = new Money(amount, currency);
+        var money = new Money(15.06m, new Currency("PLN"));
+        var equalTo = new Money(amount, new Currency(currency));
 
         // Act
         var result = money.Equals(equalTo);
 
         // Assert
         result.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(71.251, "PLN", "71,25 PLN")]
+    [InlineData(98.3104, "USD", "98,31 USD")]
+    [InlineData(184.96, "EUR", "184,96 EUR")]
+    public void ToString_WhenCalled_ShouldReturnExpectedString(
+        decimal amount,
+        string currency,
+        string expectedString
+    )
+    {
+        // Arrange
+        var cut = new Money(
+            amount,
+            new Currency(currency)
+        );
+
+        // Act
+        var result = cut.ToString();
+
+        // Assert
+        result
+            .Should()
+            .BeEquivalentTo(expectedString);
     }
 }

--- a/tests/WebAPI.Unit.Tests/MonthlyBillings/MonthlyBillingsControllerTests.cs
+++ b/tests/WebAPI.Unit.Tests/MonthlyBillings/MonthlyBillingsControllerTests.cs
@@ -8,7 +8,6 @@ using Application.MonthlyBillings.Commands.AddPlan;
 using Application.MonthlyBillings.Commands.OpenMonthlyBilling;
 using Application.MonthlyBillings.DTO;
 using Application.MonthlyBillings.Queries.GetByYearAndMonth;
-using Domain.MonthlyBillings;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using WebAPI.MonthlyBillings;
@@ -56,7 +55,7 @@ public sealed class MonthlyBillingsControllerTests
     public async Task Open_OnSuccess_ShouldReturnCreatedObjectResult()
     {
         // Act
-        var result = await _cut.Open(new(2020, 1));
+        var result = await _cut.Open(new(2020, 1, "USD"));
 
         // Assert
         result.Should().NotBeNull();
@@ -67,7 +66,7 @@ public sealed class MonthlyBillingsControllerTests
     public async Task Open_OnSuccess_ShouldReturnStatusCode201()
     {
         // Act
-        var result = (CreatedResult)await _cut.Open(new(2020, 1));
+        var result = (CreatedResult)await _cut.Open(new(2020, 1, "PLN"));
 
         // Assert
         result.StatusCode.Should().Be(201);
@@ -77,7 +76,7 @@ public sealed class MonthlyBillingsControllerTests
     public async Task Open_WhenInvoked_ShouldCallOpenMonthlyBillingCommandHandler()
     {
         // Act
-        await _cut.Open(new(2020, 1));
+        await _cut.Open(new(2020, 1, "PLN"));
 
         // Assert
         _mockOpenMonthlyBillingCommandHandler.Verify(
@@ -88,16 +87,20 @@ public sealed class MonthlyBillingsControllerTests
     }
 
     [Theory]
-    [InlineData(2020, 1)]
-    [InlineData(2021, 6)]
-    [InlineData(2022, 12)]
-    public async Task Open_WhenInvoked_ShouldPassParametersToCommand(ushort year, byte month)
+    [InlineData(2020, 1, "PLN")]
+    [InlineData(2021, 6, "EUR")]
+    [InlineData(2022, 12, "USD")]
+    public async Task Open_WhenInvoked_ShouldPassParametersToCommand(
+        ushort year,
+        byte month,
+        string currency
+    )
     {
         // Arrange
         var token = new CancellationToken();
 
         // Act
-        await _cut.Open(new(year, month));
+        await _cut.Open(new(year, month, currency));
 
         // Assert
         _mockOpenMonthlyBillingCommandHandler.Verify(
@@ -116,7 +119,8 @@ public sealed class MonthlyBillingsControllerTests
         var request = new AddIncomeRequest(
             "TEST",
             5284M,
-            "PLN");
+            "PLN"
+        );
 
         // Act
         var result = await _cut.AddIncome(Guid.NewGuid(), request);
@@ -133,7 +137,8 @@ public sealed class MonthlyBillingsControllerTests
         var request = new AddIncomeRequest(
             "TEST",
             8761.97M,
-            "PLN");
+            "PLN"
+        );
 
         // Act
         var result = (CreatedResult)await _cut.AddIncome(Guid.NewGuid(), request);

--- a/tests/WebAPI.Unit.Tests/MonthlyBillings/MonthlyBillingsControllerTests.cs
+++ b/tests/WebAPI.Unit.Tests/MonthlyBillings/MonthlyBillingsControllerTests.cs
@@ -116,7 +116,7 @@ public sealed class MonthlyBillingsControllerTests
         var request = new AddIncomeRequest(
             "TEST",
             5284M,
-            Currency.PLN);
+            "PLN");
 
         // Act
         var result = await _cut.AddIncome(Guid.NewGuid(), request);
@@ -133,7 +133,7 @@ public sealed class MonthlyBillingsControllerTests
         var request = new AddIncomeRequest(
             "TEST",
             8761.97M,
-            Currency.PLN);
+            "PLN");
 
         // Act
         var result = (CreatedResult)await _cut.AddIncome(Guid.NewGuid(), request);
@@ -149,7 +149,7 @@ public sealed class MonthlyBillingsControllerTests
         var request = new AddIncomeRequest(
             "TEST",
             3456.20M,
-            Currency.EUR);
+            "EUR");
 
         // Act
         await _cut.AddIncome(Guid.NewGuid(), request);
@@ -163,8 +163,8 @@ public sealed class MonthlyBillingsControllerTests
     }
 
     [Theory]
-    [InlineData("2b715a6c-b187-4885-9344-c35f7f639f97", "TEST", 3680.70, Currency.PLN, true)]
-    public async Task AddIncome_WhenInvoked_ShouldPassParametersToCommand(Guid monthlyBillingId, string name, decimal amount, Currency currency, bool include)
+    [InlineData("2b715a6c-b187-4885-9344-c35f7f639f97", "TEST", 3680.70, "PLN", true)]
+    public async Task AddIncome_WhenInvoked_ShouldPassParametersToCommand(Guid monthlyBillingId, string name, decimal amount, string currency, bool include)
     {
         // Arrange
         var request = new AddIncomeRequest(
@@ -204,7 +204,7 @@ public sealed class MonthlyBillingsControllerTests
             new AddPlanRequest(
                 "Shopping",
                 100.0M,
-                Currency.PLN,
+                "PLN",
                 1
             )
         );
@@ -223,7 +223,7 @@ public sealed class MonthlyBillingsControllerTests
             new AddPlanRequest(
                 "Shopping",
                 100.0M,
-                Currency.PLN,
+                "PLN",
                 1
             ));
 
@@ -238,7 +238,7 @@ public sealed class MonthlyBillingsControllerTests
         var addPlanRequest = new AddPlanRequest(
             "Food",
             10.0M,
-            Currency.PLN,
+            "PLN",
             1
         );
 
@@ -261,7 +261,7 @@ public sealed class MonthlyBillingsControllerTests
         var addPlanRequest = new AddPlanRequest(
             "Fuel",
             87.96M,
-            Currency.PLN,
+            "PLN",
             5
         );
 
@@ -277,7 +277,7 @@ public sealed class MonthlyBillingsControllerTests
                 It.Is<AddPlanCommand>(
                     c => c.Category == "Fuel"
                     && c.MoneyAmount == 87.96M
-                    && c.Currency == Currency.PLN
+                    && c.Currency == "PLN"
                     && c.SortOrder == 5
                 ),
                 default
@@ -290,7 +290,7 @@ public sealed class MonthlyBillingsControllerTests
         // Arrange
         var request = new AddExpenseRequest(
             154.09M,
-            Currency.USD,
+            "USD",
             new DateTimeOffset(new DateTime(2023, 4, 1)),
             "Description"
         );
@@ -318,7 +318,7 @@ public sealed class MonthlyBillingsControllerTests
         // Arrange
         var request = new AddExpenseRequest(
             154.09M,
-            Currency.USD,
+            "USD",
             new DateTimeOffset(new DateTime(2023, 4, 1)),
             "Description"
         );
@@ -342,7 +342,7 @@ public sealed class MonthlyBillingsControllerTests
         // Arrange
         var request = new AddExpenseRequest(
             154.09M,
-            Currency.USD,
+            "USD",
             new DateTimeOffset(new DateTime(2023, 4, 1)),
             "Description"
         );
@@ -369,7 +369,7 @@ public sealed class MonthlyBillingsControllerTests
         // Arrange
         var request = new AddExpenseRequest(
             125.04M,
-            Currency.PLN,
+            "PLN",
             new DateTimeOffset(new DateTime(2023, 5, 1)),
             "TEST"
         );
@@ -391,7 +391,7 @@ public sealed class MonthlyBillingsControllerTests
                     c => c.MonthlyBillingId == monthlyBillingId
                     && c.PlanId == planId
                     && c.Money == 125.04M
-                    && c.Currency == Currency.PLN
+                    && c.Currency == "PLN"
                     && c.ExpenseDate == new DateTimeOffset(new DateTime(2023, 5, 1))
                     && c.Description == "TEST"
                 ),


### PR DESCRIPTION
### What?

Added new own type `Currency` for containing currency (especially for `Money` object). \
Also, added invariant checking for monthly billing currency - when opening new monthly billing, you need to pass currency. Then for plans, incomes and expenses the currency must match the currency of the monthly billing.

For this moment, application supports only three currencies: PLN, USD and EUR. \
Currency is only for viewing, there are no any exchanging rates (for now).

### Why?

Earlier, it was simple `enum`, which had a few drawbacks - it couldn't be easily passed in request (user had to pass integer).

### How?

Added new vaulue object class named `Currency` with own implementations of `Equals()` methods (because private `string[]` field was causing equality problems). \
Added `Currency` to monthly billing opening request. \
Added currency checking for adding income, plan and expense.

#### Additional informations
- added new unit tests for currency invariant,
- refactored unit tests for monthly billings (new currency field),
- improved EntityFrameworkCore configuration for `Plan`, `Expense`, `Income` and `MonthlyBilling` to contain `Money` and `Currency` fields.

Related to #14 