### PR TITLE
#18 Fix - Two same plans can be added

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Smuget is smart home bugdet manager application for your home finances and piggy
 - [Found a bug](#found-a-bug)
 
 ## General info
-This repository is part of set of applications that works together. This module is responsible for the backend part of the `smuget` application.
-`smuget` is the application that will help you with your home buget planning, saving and spending money. It allows you to create moneyboxes to differentiant other finances from your main buget (for example savings for a car or for the future).
+This repository is part of set of applications that works together. This module is responsible for the backend part of the 'smuget` application.
+'smuget` is the application that will help you with your home buget planning, saving and spending money. It allows you to create moneyboxes to differentiant other finances from your main buget (for example savings for a car or for the future).
 
 ## Technologies
 PRoject is built with:

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Smuget is smart home bugdet manager application for your home finances and piggy
 - [Found a bug](#found-a-bug)
 
 ## General info
-This repository is part of set of applications that works together. This module is responsible for the backend part of the 'smuget` application.
-'smuget` is the application that will help you with your home buget planning, saving and spending money. It allows you to create moneyboxes to differentiant other finances from your main buget (for example savings for a car or for the future).
+This repository is part of set of applications that works together. This module is responsible for the backend part of the `smuget` application.
+`smuget` is the application that will help you with your home buget planning, saving and spending money. It allows you to create moneyboxes to differentiate other finances from your main buget (for example savings for a car or for the future).
 
 ## Technologies
-PRoject is built with:
+Project is built with:
 - [.NET](https://docs.microsoft.com/pl-pl/dotnet) - .NET is a free, cross-platform, open source developer platform for building many different types of applications. With .NET, you can use multiple languages, editors, and libraries to build for web, mobile, desktop, games, IoT, and more.
 - [MSSQL Server](https://www.microsoft.com/pl-pl/sql-server/) -  is a relational database management system developed by Microsoft. As a database server, it is a software product with the primary function of storing and retrieving data as requested by other software applications—which may run either on the same computer or on another computer across a network (including the Internet).
 

--- a/src/Application/Exceptions/MonthlyBillingAlreadyOpenedException.cs
+++ b/src/Application/Exceptions/MonthlyBillingAlreadyOpenedException.cs
@@ -5,5 +5,5 @@ namespace Application.Exceptions;
 public sealed class MonthlyBillingAlreadyOpenedException : SmugetException
 {
     public MonthlyBillingAlreadyOpenedException(byte month, ushort year)
-        : base($"You already have opened monthly billing for '{month}/{year}'.") { }
+        : base($"You already have opened monthly billing for `{month}/{year}`.") { }
 }

--- a/src/Domain/Exceptions/IncomeNameNotUniqueException.cs
+++ b/src/Domain/Exceptions/IncomeNameNotUniqueException.cs
@@ -3,5 +3,5 @@ namespace Domain.Exceptions;
 public sealed class IncomeNameNotUniqueException : SmugetException
 {
     public IncomeNameNotUniqueException(string name)
-        : base($"Income`s name `{ name }` already exists in monthly billing.") { }
+        : base($"Income's name `{ name }` already exists in monthly billing.") { }
 }

--- a/src/Domain/Exceptions/InvalidCurrencyException.cs
+++ b/src/Domain/Exceptions/InvalidCurrencyException.cs
@@ -7,7 +7,7 @@ public sealed class InvalidCurrencyException : SmugetException
     public InvalidCurrencyException(
         string currency
     )
-        : base($"There is no currency like '{currency}' supported in application.")
+        : base($"There is no currency like `{currency}` supported in application.")
     {
         Currency = currency;
     }

--- a/src/Domain/Exceptions/MonthlyBillingAlreadyClosedException.cs
+++ b/src/Domain/Exceptions/MonthlyBillingAlreadyClosedException.cs
@@ -5,5 +5,5 @@ namespace Domain.Exceptions;
 public sealed class MonthlyBillingAlreadyClosedException : SmugetException
 {
     public MonthlyBillingAlreadyClosedException(Month month, Year year)
-        : base($"Monthly billing for '{month.Value}/{year.Value}' is already closed.") { }
+        : base($"Monthly billing for `{month.Value}/{year.Value}` is already closed.") { }
 }

--- a/src/Domain/Exceptions/MonthlyBillingCurrencyMismatchException.cs
+++ b/src/Domain/Exceptions/MonthlyBillingCurrencyMismatchException.cs
@@ -9,7 +9,7 @@ public sealed class MonthlyBillingCurrencyMismatchException : SmugetException
     public MonthlyBillingCurrencyMismatchException(
         Currency currency
     )
-        : base($"The currency '{currency.Value}' doesn't match monthly billing's currency.")
+        : base($"The currency `{currency.Value}` doesn't match monthly billing's currency.")
     {
         Currency = currency;
     }

--- a/src/Domain/Exceptions/PlanNotFoundException.cs
+++ b/src/Domain/Exceptions/PlanNotFoundException.cs
@@ -7,7 +7,7 @@ public sealed class PlanNotFoundException : SmugetException
     public PlanId PlanId { get; private set; }
 
     public PlanNotFoundException(PlanId planId)
-        : base($"Plan with id = '{planId}' doesn't exists.")
+        : base($"Plan with id = `{planId}` doesn't exists.")
     {
         PlanId = planId;
     }

--- a/src/Domain/Exceptions/PlanNotUniqueException.cs
+++ b/src/Domain/Exceptions/PlanNotUniqueException.cs
@@ -1,0 +1,15 @@
+namespace Domain.Exceptions;
+
+public sealed class PlanCategoryNotUniqueException : SmugetException
+{
+    public string Category { get; }
+
+    public PlanCategoryNotUniqueException(
+        string category
+    )
+        : base($"Plan's category `{category}` already exists int monthly billing.")
+    {
+        Category = category;
+    }
+
+}

--- a/src/Domain/MonthlyBillings/Category.cs
+++ b/src/Domain/MonthlyBillings/Category.cs
@@ -2,9 +2,10 @@ using Domain.Exceptions;
 
 namespace Domain.MonthlyBillings;
 
-public sealed class Category
+public sealed record Category
 {
     private const byte MaxLengthForCategoryName = 20;
+
     public string Value { get; }
 
     public Category(string value)

--- a/src/Domain/MonthlyBillings/MonthlyBilling.cs
+++ b/src/Domain/MonthlyBillings/MonthlyBilling.cs
@@ -79,6 +79,11 @@ public sealed class MonthlyBilling
             throw new PlanIsNullException();
         }
 
+        if (_plans.Any(p => p.Category.Equals(plan.Category)))
+        {
+            throw new PlanCategoryNotUniqueException(plan.Category.Value);
+        }
+
         if (plan.Money.Currency != Currency)
         {
             throw new MonthlyBillingCurrencyMismatchException(plan.Money.Currency);

--- a/tests/Domain.Unit.Tests/MonthlyBillings/MonthlyBillingTests.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/MonthlyBillingTests.cs
@@ -223,6 +223,27 @@ public sealed class MonthlyBillingTests
     }
 
     [Fact]
+    public void AddPlan_WhenTryingToAddPlanWithSameCategory_ShouldThrowPlanCategoryNotUniqueExceptionn()
+    {
+        // Arrange
+        var cut = MonthlyBillingUtilities.CreateMonthlyBilling();
+
+        Plan plan = new Plan(
+            new Category("Category 0"),
+            new Money(
+                123.45M,
+                new Currency("PLN")
+            ),
+            1
+        );
+
+        var addPlan = () => cut.AddPlan(plan);
+
+        // Act & Assert
+        Assert.Throws<PlanCategoryNotUniqueException>(addPlan);
+    }
+
+    [Fact]
     public void AddPlan_WhenTryingToAddPlanWithOtherCurrency_ShouldThrowMonthlyBillingCurrencyMismatchException()
     {
         // Arrange


### PR DESCRIPTION
### What?

Fixing bug with adding two (or more) plans with same category.

### Why?

Category should be unique in monthly billing.

### How?

Adding invariant in `MonthlyBilling` that checks, before adding a plan, if there is already a plan with same category. \
If yes, `PlanCategoryNotUniqueException` exception is thrown.

#### Additional informations
- added unit tests for this case,
- changed `Category` type from `class` to `record` for `value-type` equality.

Related to #18 