### PR TITLE
#5 Feature - Adding global exception middleware

### DIFF
--- a/src/Infrastructure/Exceptions/ExceptionMiddleware.cs
+++ b/src/Infrastructure/Exceptions/ExceptionMiddleware.cs
@@ -1,0 +1,60 @@
+using Domain.Exceptions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.Exceptions;
+
+internal sealed class ExceptionMiddleware : IMiddleware
+{
+    private readonly ILogger<ExceptionMiddleware> _logger;
+
+    public ExceptionMiddleware(
+        ILogger<ExceptionMiddleware> logger
+    )
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        try
+        {
+            await next(context);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, exception.Message);
+            await HandleExceptionAsync(exception, context);
+        }
+    }
+
+    private async Task HandleExceptionAsync(Exception exception, HttpContext context)
+    {
+        var (statusCode, error) = exception switch
+        {
+            SmugetException => (StatusCodes.Status400BadRequest,
+                new Error(
+                    exception.Message,
+                    exception.GetType().Name?.Replace("Exception", "") ?? "Exception",
+                    context.Request.Path
+                )
+            ),
+            _ => (StatusCodes.Status500InternalServerError,
+                new Error(
+                    "Wystąpił błąd serwera. Proszę się skontaktować z Administratorem.",
+                    "Exception",
+                    context.Request.Path
+                )
+            )
+        };
+
+        context.Response.StatusCode = statusCode;
+        await context.Response.WriteAsJsonAsync(error);
+    }
+
+    private record Error(
+        string Reason,
+        string Code,
+        string Instance
+    );
+}

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -9,6 +9,10 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.4" />
   </ItemGroup>
 
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Infrastructure/InfrastructureExtensions.cs
+++ b/src/Infrastructure/InfrastructureExtensions.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Infrastructure.Persistance;
+using Infrastructure.Exceptions;
+using Microsoft.AspNetCore.Builder;
 
 namespace Infrastructure;
 
@@ -9,6 +11,15 @@ public static class InfrastructureExtensions
     {
         services.AddDbContext();
 
+        services.AddSingleton<ExceptionMiddleware>();
+
         return services;
+    }
+
+    public static WebApplication UseInfrastructure(this WebApplication app)
+    {
+        app.UseMiddleware<ExceptionMiddleware>();
+
+        return app;
     }
 }

--- a/src/WebAPI/Program.cs
+++ b/src/WebAPI/Program.cs
@@ -14,6 +14,8 @@ var builder = WebApplication.CreateBuilder(args);
 
 var app = builder.Build();
 {
+    app.UseInfrastructure();
+
     app.UseSwagger();
     app.UseSwaggerUI();
 


### PR DESCRIPTION
### What?

I've added global exception middleware for cleaner responses on error. All errors from API will be transalted to `Error` record which contains:

```json
{
    "reason": "exception message",
    "code": "exception code",
    "instace": "path to action from controller"
}
```

### Why?

Before these changes, all exceptions were written to the response as `text/plain` with whole stack trace. It wasn't clean and readable. It also had security issues (stack trace is sensitive).

### How?

I added 'ExceptionMiddleware' class which implements `IMiddleware` interface from AspNetCore framework. \
In this middleware I check exceptions type. If it is of `SumgetException` type I translate it's message and name to reason and code. Then it's returned as `BadRequest 400`\
For any other excpetions, I return `InternalServerError` 500 with simple code and message.

#### Additional informations

Example response for open monthly billing:

```json
{
  "reason": "You already have opened monthly billing for `4/2023`.",
  "code": "MonthlyBillingAlreadyOpened",
  "instance": "/api/monthlyBillings"
}
```

Related to #5