### PR TITLE
Changing MonthlyBilling's State to own type

### DIFF
--- a/src/Application/MonthlyBillings/DTO/MonthlyBillingDTO.cs
+++ b/src/Application/MonthlyBillings/DTO/MonthlyBillingDTO.cs
@@ -5,7 +5,7 @@ public sealed class MonthlyBillingDTO
     public string Id { get; set; }
     public int Year { get; set; }
     public int Month { get; set; }
-    public int State { get; set; }
+    public string State { get; set; }
     public IEnumerable<IncomeDTO> Incomes { get; set; }
     public IEnumerable<PlanDTO> Plans { get; set; }
 }

--- a/src/Application/MonthlyBillings/Mappings/MonthlyBillingMappings.cs
+++ b/src/Application/MonthlyBillings/Mappings/MonthlyBillingMappings.cs
@@ -17,7 +17,7 @@ public static class MonthlyBillingMappingsExtension
             Id = domain.Id.Value.ToString(),
             Year = domain.Year.Value,
             Month = domain.Month.Value,
-            State = (int)domain.State,
+            State = domain.State.ToString(),
             Incomes = domain.Incomes
                 .Select(i => i.ToDTO())
                 .ToList(),

--- a/src/Domain/Abstractions/Enumeration.cs
+++ b/src/Domain/Abstractions/Enumeration.cs
@@ -1,0 +1,44 @@
+using System.Reflection;
+
+namespace Domain.Abstractions;
+
+public abstract record Enumeration<T>
+    where T : Enumeration<T>
+{
+    public int Id { get; private set; }
+    public string Name { get; private set; }
+
+    protected Enumeration(int id, string name)
+    {
+        Id = id;
+        Name = name;
+    }
+
+    public override string ToString()
+        => Name;
+
+    public static T GetById(int id)
+    {
+        return GetAll<T>()
+            .Single(s => s.Id == id);
+    }
+
+    public static T GetByName(string name)
+    {
+        return GetAll<T>()
+            .Single(s => s.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase));
+    }
+
+    private static IEnumerable<T> GetAll<T>()
+    {
+        var fields = typeof(T).GetFields(
+            BindingFlags.Public |
+            BindingFlags.Static |
+            BindingFlags.DeclaredOnly
+        );
+
+        return fields
+            .Select(f => f.GetValue(null))
+            .Cast<T>();
+    }
+}

--- a/src/Domain/MonthlyBillings/State.cs
+++ b/src/Domain/MonthlyBillings/State.cs
@@ -1,7 +1,18 @@
+using Domain.Abstractions;
+
 namespace Domain.MonthlyBillings;
 
-public enum State
+public sealed record State : Enumeration<State>
 {
-    Open,
-    Closed
+    public static State Open = new State(1, "Open");
+    public static State Closed = new State(2, "Closed");
+
+    private State(int id, string name)
+        : base(id, name)
+    {
+
+    }
+
+    public override string ToString()
+        => base.ToString();
 }

--- a/src/Infrastructure/Migrations/20230830062423_MakingStateStringValueObject.Designer.cs
+++ b/src/Infrastructure/Migrations/20230830062423_MakingStateStringValueObject.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistance;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(SmugetDbContext))]
-    partial class SmugetDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230830062423_MakingStateStringValueObject")]
+    partial class MakingStateStringValueObject
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20230830062423_MakingStateStringValueObject.cs
+++ b/src/Infrastructure/Migrations/20230830062423_MakingStateStringValueObject.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakingStateStringValueObject : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "State",
+                table: "MonthlyBillings",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "State",
+                table: "MonthlyBillings",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+        }
+    }
+}

--- a/src/Infrastructure/Persistance/Configurations/MonthlyBillingEntityConfirguration.cs
+++ b/src/Infrastructure/Persistance/Configurations/MonthlyBillingEntityConfirguration.cs
@@ -31,6 +31,10 @@ internal sealed class MonthlyBillingEntityConfiguration : IEntityTypeConfigurati
             .IsRequired();
 
         builder
+            .Property(b => b.State)
+            .IsRequired();
+
+        builder
             .HasMany(b => b.Incomes)
             .WithOne()
             .HasForeignKey(i => i.MonthlyBillingId)

--- a/src/Infrastructure/Persistance/Entities/Mappings/MonthlyBillingMappingExtensions.cs
+++ b/src/Infrastructure/Persistance/Entities/Mappings/MonthlyBillingMappingExtensions.cs
@@ -16,7 +16,7 @@ internal static class MonthlyBillingMappingExtensions
             new Year(entity.Year),
             new Month(entity.Month),
             new Currency(entity.Currency),
-            entity.State == 0 ? State.Open : State.Closed,  // TODO: Make VO
+            State.GetByName(entity.State),
             entity.Plans.ConvertAll(
                 p => p.ToDomain()
             ),
@@ -33,7 +33,7 @@ internal static class MonthlyBillingMappingExtensions
             Id = domain.Id.Value,
             Year = domain.Year.Value,
             Month = domain.Month.Value,
-            State = (int)domain.State,
+            State = domain.State.ToString(),
             Currency = domain.Currency.Value,
             Plans = domain.Plans.Select(
                 p => p.ToEntity(domain.Id.Value)

--- a/src/Infrastructure/Persistance/Entities/MonthlyBillingEntity.cs
+++ b/src/Infrastructure/Persistance/Entities/MonthlyBillingEntity.cs
@@ -5,7 +5,7 @@ internal sealed class MonthlyBillingEntity
     public Guid Id { get; set; }
     public int Year { get; set; }
     public int Month { get; set; }
-    public int State { get; set; }
+    public string State { get; set; }
     public string Currency { get; set; }
     public List<IncomeEntity> Incomes { get; set; }
     public List<PlanEntity> Plans { get; set; }

--- a/tests/Domain.Unit.Tests/MonthlyBillings/MonthlyBillingTests.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/MonthlyBillingTests.cs
@@ -370,7 +370,9 @@ public sealed class MonthlyBillingTests
         cut.Close();
 
         // Assert
-        cut.State.Should().Be(State.Closed);
+        cut.State
+            .Should()
+            .Be(State.Closed);
     }
 
     [Fact]

--- a/tests/Domain.Unit.Tests/MonthlyBillings/ValueObjects/StateTests.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/ValueObjects/StateTests.cs
@@ -1,0 +1,82 @@
+using Domain.MonthlyBillings;
+
+namespace Domain.Unit.Tests.MonthlyBillings.ValueObjects;
+
+public sealed class StateTests
+{
+    [Fact]
+    public void State_Open_ShouldReturnExpectedObject()
+    {
+        // Arrange
+        var createState = () => State.Open;
+
+        // Act
+        var result = createState();
+
+        // Assert
+        result
+            .Should()
+            .NotBeNull();
+
+        result
+            .Should()
+            .Match<State>(
+                s => s.Id == 1
+                  && s.Name == "Open"
+            );
+    }
+
+    [Fact]
+    public void State_Closed_ShouldReturnExpectedObject()
+    {
+        // Arrange
+        var createState = () => State.Closed;
+
+        // Act
+        var result = createState();
+
+        // Assert
+        result
+            .Should()
+            .NotBeNull();
+
+        result
+            .Should()
+            .Match<State>(
+                s => s.Id == 2
+                  && s.Name == "Closed"
+            );
+    }
+
+    [Fact]
+    public void State_WhenComapredToStateWithSameValues_ShouldReturnTrue()
+    {
+        // Arrange
+        var openState = State.Open;
+        var compareTo = State.Open;
+
+        // Act
+        var result = openState.Equals(compareTo);
+
+        // Assert
+        result
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public void State_WhenComapredToStateWithOtherValues_ShouldReturnFalse()
+    {
+        // Arrange
+        var openState = State.Open;
+        var compareTo = State.Closed;
+
+        // Act
+        var result = openState.Equals(compareTo);
+
+        // Assert
+        result
+            .Should()
+            .BeFalse();
+    }
+}

--- a/tests/WebAPI.Unit.Tests/WebAPI.Unit.Tests.csproj
+++ b/tests/WebAPI.Unit.Tests/WebAPI.Unit.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Moq" Version="[4.18.4]" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
### What?

I've changed `State` property in `MonthlyBilling` model from `enum` to own type based on `Enumeration<T>`.

### Why?

Before, `State` was `enum` type and was save to database as `int` type. \
Changing to own type allowed me to easy map between `string` (name of the object enumeration) and object (that can have more logic in the future).

### How?

I've implemented base `Enumeartion<T>` abstract record which contains two properties: id and name, they describe the enumeration object. In this record, there are two helper methods for getting enumeration by Id or by Name.
Then I added 'State' record which derives form `Enumeration<T>` and it contains two static fields for two states: Open and Closed. It also contains `ToString()` method override for easier mapping to database text value.

When getting mothly billing now `State` is more readable than before:

Before:
```json
{
    "id": "5cb3c291-de21-4abc-b0e2-f1614c18ceb6",
    "year": 2023,
    "month": 9,
    "state": 1,
    "incomes": [],
    "plans": []
}
```

After:
```json
{
    "id": "5cb3c291-de21-4abc-b0e2-f1614c18ceb6",
    "year": 2023,
    "month": 9,
    "state": "Open",
    "incomes": [],
    "plans": []
}
```

#### Additional informations

- Added unit tests for `State` object,
- Locked `Moq` NuGet package on 4.18.* version

Related to #21 