### PR TITLE
#35 Feature - Adding Swagger documentation with some examples

### DIFF
--- a/src/Infrastructure/Exceptions/Error.cs
+++ b/src/Infrastructure/Exceptions/Error.cs
@@ -1,0 +1,7 @@
+namespace Infrastructure.Exceptions;
+
+public record Error(
+    string Reason,
+    string Code,
+    string Instance
+);

--- a/src/Infrastructure/Exceptions/ExceptionMiddleware.cs
+++ b/src/Infrastructure/Exceptions/ExceptionMiddleware.cs
@@ -51,10 +51,4 @@ internal sealed class ExceptionMiddleware : IMiddleware
         context.Response.StatusCode = statusCode;
         await context.Response.WriteAsJsonAsync(error);
     }
-
-    private record Error(
-        string Reason,
-        string Code,
-        string Instance
-    );
 }

--- a/src/WebAPI/MonthlyBillings/AddExpenseRequest.cs
+++ b/src/WebAPI/MonthlyBillings/AddExpenseRequest.cs
@@ -1,10 +1,35 @@
-using Domain.MonthlyBillings;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.Annotations;
+using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace WebAPI.MonthlyBillings;
 
+/// <summary>
+/// Informations about new expense.
+/// </summary>
+/// <param name="Money">Amount of the expense.</param>
+/// <param name="Currency">Currency of the expense.</param>
+/// <param name="ExpenseDate">When the expense happened.</param>
+/// <param name="Description">Short description about the expense.</param>
+[SwaggerSchemaFilter(typeof(AddExpenseRequestFilter))]
 public sealed record AddExpenseRequest(
     decimal Money,
     string Currency,
     DateTimeOffset ExpenseDate,
     string Description
 );
+
+public class AddExpenseRequestFilter : ISchemaFilter
+{
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        schema.Example = new OpenApiObject()
+        {
+            ["Money"] = new OpenApiDouble(256.97),
+            ["Currency"] = new OpenApiString("PLN"),
+            ["ExpenseDate"] = new OpenApiDateTime(new DateTimeOffset(new DateTime(2023, 09, 13, 15, 34, 11))),
+            ["Description"] = new OpenApiString("Medicines")
+        };
+    }
+}

--- a/src/WebAPI/MonthlyBillings/AddIncomeRequest.cs
+++ b/src/WebAPI/MonthlyBillings/AddIncomeRequest.cs
@@ -1,5 +1,12 @@
 namespace WebAPI.MonthlyBillings;
 
+/// <summary>
+/// Informations about new income for monthly billing.
+/// </summary>
+/// <param name="Name">Tag name for income.</param>
+/// <param name="MoneyAmount">Amount of the income.</param>
+/// <param name="Currency">Currency of the income.</param>
+/// <param name="IncludeInBilling">Include in total amount of money available for planning?</param>
 public sealed record AddIncomeRequest(
     string Name,
     decimal MoneyAmount,

--- a/src/WebAPI/MonthlyBillings/AddPlanRequest.cs
+++ b/src/WebAPI/MonthlyBillings/AddPlanRequest.cs
@@ -1,7 +1,12 @@
-using Domain.MonthlyBillings;
-
 namespace WebAPI.MonthlyBillings;
 
+/// <summary>
+/// Informations about new plan in monthly billing.
+/// </summary>
+/// <param name="Category">Tag name for the plan.</param>
+/// <param name="Money">Amount of the plan.</param>
+/// <param name="Currency">Currency of the plan.</param>
+/// <param name="SortOrder">Order number.</param>
 public sealed record AddPlanRequest(
     string Category,
     decimal Money,

--- a/src/WebAPI/MonthlyBillings/GetMonthlyBillingRequest.cs
+++ b/src/WebAPI/MonthlyBillings/GetMonthlyBillingRequest.cs
@@ -2,6 +2,11 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace WebAPI.MonthlyBillings;
 
+/// <summary>
+///  
+/// </summary>
+/// <param name="Year">Year of the monthly billing</param>
+/// <param name="Month">Month of the monthly billing</param>
 public sealed record GetMonthlyBillingRequest(
     [FromRoute(Name = "year")] ushort Year,
     [FromRoute(Name = "month")] byte Month

--- a/src/WebAPI/MonthlyBillings/OpenMonthlyBillingRequest.cs
+++ b/src/WebAPI/MonthlyBillings/OpenMonthlyBillingRequest.cs
@@ -1,5 +1,11 @@
 namespace WebAPI.MonthlyBillings;
 
+/// <summary>
+/// Informations about monthly billing you try to open.
+/// </summary>
+/// <param name="Year">Year of the monthly billing.</param>
+/// <param name="Month">Monthly of the monthly billing.</param>
+/// <param name="Currency">Currency for monthly billing.</param>
 public sealed record OpenMonthlyBillingRequest(
     ushort Year,
     byte Month,

--- a/src/WebAPI/Program.cs
+++ b/src/WebAPI/Program.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Application;
 using Infrastructure;
 using WebAPI.Middlewares;
@@ -12,7 +13,13 @@ var builder = WebApplication.CreateBuilder(args);
 
     builder.Services.AddControllers();
     builder.Services.AddEndpointsApiExplorer();
-    builder.Services.AddSwaggerGen();
+    builder.Services.AddSwaggerGen(options =>
+    {
+        options.EnableAnnotations();
+
+        var xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+        options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename));
+    });
 }
 
 var app = builder.Build();

--- a/src/WebAPI/WebAPI.csproj
+++ b/src/WebAPI/WebAPI.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,7 +13,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### What?

I added Swagger support with parameters descriptions and one example for the expense.

### Why?

With Swagger it would be easier to test the API for new users.

### How?

Added `Swashbuckle.AspNetCore` NuGet package and included XML comments in `WebAPI.csproj`. \
Added some `///` comments for API endpoints.

![obraz](https://github.com/PanKunik/smuget/assets/30160044/810d8b8a-0fba-41c6-9052-ee3a98a96606)

Related to #35 