### PR TITLE
#24 Feature - Add income summary

### DIFF
--- a/src/Application/MonthlyBillings/DTO/MonthlyBillingDTO.cs
+++ b/src/Application/MonthlyBillings/DTO/MonthlyBillingDTO.cs
@@ -8,4 +8,6 @@ public sealed class MonthlyBillingDTO
     public string State { get; set; }
     public IEnumerable<IncomeDTO> Incomes { get; set; }
     public IEnumerable<PlanDTO> Plans { get; set; }
+    public decimal SumOfIncome { get; set; }
+    public decimal SumOfIncomeAvailableForPlanning { get; set; }
 }

--- a/src/Application/MonthlyBillings/Mappings/MonthlyBillingMappings.cs
+++ b/src/Application/MonthlyBillings/Mappings/MonthlyBillingMappings.cs
@@ -23,7 +23,9 @@ public static class MonthlyBillingMappingsExtension
                 .ToList(),
             Plans = domain.Plans
                 .Select(p => p.ToDTO())
-                .ToList()
+                .ToList(),
+            SumOfIncome = domain.SumOfIncome,
+            SumOfIncomeAvailableForPlanning = domain.SumOfIncomeAvailableForPlanning,
         };
     }
 }

--- a/src/Domain/MonthlyBillings/MonthlyBilling.cs
+++ b/src/Domain/MonthlyBillings/MonthlyBilling.cs
@@ -16,6 +16,12 @@ public sealed class MonthlyBilling
     public State State { get; private set; } = State.Open;
     public IReadOnlyCollection<Income> Incomes => _incomes.AsReadOnly();
     public IReadOnlyCollection<Plan> Plans => _plans.AsReadOnly();
+    public decimal SumOfIncome
+        => _incomes?.Sum(i => i.Money.Amount) ?? 0m;
+    public decimal SumOfIncomeAvailableForPlanning
+        => _incomes?
+            .Where(i => i.Include)
+            .Sum(i => i.Money.Amount) ?? 0m;
 
     public MonthlyBilling(
         MonthlyBillingId monthlyBillingId,

--- a/tests/Application.Unit.Tests/MonthlyBillings/Queries/GetByYearAndMonth/GetByYearAndMonthQueryHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/Queries/GetByYearAndMonth/GetByYearAndMonthQueryHandlerTests.cs
@@ -1,0 +1,114 @@
+using Application.Exceptions;
+using Application.MonthlyBillings.DTO;
+using Application.MonthlyBillings.Queries.GetByYearAndMonth;
+using Application.Unit.Tests.MonthlyBillings.Queries.TestUtils;
+using Application.Unit.Tests.TestUtils;
+using Application.Unit.Tests.TestUtils.Constants;
+using Domain.MonthlyBillings;
+using Domain.Repositories;
+
+namespace Application.Unit.Tests.MonthlyBillings.Queries.GetByYearAndMonth;
+
+public sealed class GetByYearAndMonthQueryHandlerTests
+{
+    private readonly IMonthlyBillingRepository _repository;
+    private readonly GetMonthlyBillingByYearAndMonthQueryHandler _handler;
+
+    public GetByYearAndMonthQueryHandlerTests()
+    {
+        _repository = Substitute.For<IMonthlyBillingRepository>();
+
+        _handler = new GetMonthlyBillingByYearAndMonthQueryHandler(_repository);
+    }
+
+    [Theory]
+    [InlineData(2023, 9)]
+    [InlineData(2022, 1)]
+    public async Task HandleAsync_WhenCalled_ShouldCallGetOnRepository(int year, int month)
+    {
+        // Arrange
+        var query = new GetMonthlyBillingByYearAndMonthQuery(
+            (ushort)year,
+            (byte)month
+        );
+
+        _repository
+            .Get(
+                new(year),
+                new(month)
+            )
+            .Returns(
+                new MonthlyBilling(
+                    new(Constants.MonthlyBilling.Id),
+                    new(year),
+                    new(month),
+                    new(Constants.MonthlyBilling.Currency),
+                    Constants.MonthlyBilling.State,
+                    null,
+                    null
+                )
+            );
+
+        // Act
+        var result = await _handler.HandleAsync(
+            query,
+            default
+        );
+
+        // Assert
+        await _repository
+            .Received(1)
+            .Get(
+                Arg.Is<Year>(y => y.Value == year),
+                Arg.Is<Month>(m => m.Value == month)
+            );
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenMonthlyBillingNotFound_ShouldReturnMonthlyBillingNotFoundException()
+    {
+        // Arrange
+        var query = GetMonthlyBillingByYearAndMonthQueryUtils.CreateQuery();
+        var get = () => _handler.HandleAsync(query, default);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<MonthlyBillingNotFoundException>(get);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenCalled_ShouldReturnExpectedObject()
+    {
+        // Arrange
+        var query = GetMonthlyBillingByYearAndMonthQueryUtils.CreateQuery();
+
+        _repository
+            .Get(
+                new(Constants.MonthlyBilling.Year),
+                new(Constants.MonthlyBilling.Month)
+            )
+            .Returns(
+                MonthlyBillingUtils.CreateMonthlyBilling()
+            );
+
+        // Act
+        var result = await _handler.HandleAsync(
+            query,
+            default
+        );
+
+        // Assert
+        result
+            .Should()
+            .NotBeNull();
+
+        result
+            .Should()
+            .Match<MonthlyBillingDTO>(
+                m => m.Year == Constants.MonthlyBilling.Year
+                  && m.Month == Constants.MonthlyBilling.Month
+                  && m.State == Constants.MonthlyBilling.State.Name
+                  && m.SumOfIncome == 0m
+                  && m.SumOfIncomeAvailableForPlanning == 0m
+            );
+    }
+}

--- a/tests/Application.Unit.Tests/MonthlyBillings/Queries/TestUtils/GetMonthlyBillingByYearAndMonthQueryUtils.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/Queries/TestUtils/GetMonthlyBillingByYearAndMonthQueryUtils.cs
@@ -1,0 +1,13 @@
+using Application.MonthlyBillings.Queries.GetByYearAndMonth;
+using Application.Unit.Tests.TestUtils.Constants;
+
+namespace Application.Unit.Tests.MonthlyBillings.Queries.TestUtils;
+
+public static class GetMonthlyBillingByYearAndMonthQueryUtils
+{
+    public static GetMonthlyBillingByYearAndMonthQuery CreateQuery()
+        => new(
+            Constants.MonthlyBilling.Year,
+            Constants.MonthlyBilling.Month
+        );
+}


### PR DESCRIPTION
### What?

I've added incomes summary - sum of all incomes and sum of incomes for planning (with `Inclue` flag set to `true`).

### Why?

These sums would be helpful for calculating account value and estimated savings. \
Sometimes, user may want to add income that won't be included in planning - for example if he has cash on account that he doesn't want to spend.

### How?

I added new properties in `MonthlyBilling` aggregate root class named: `SumOfIncome` and `SumOfIncomeAvailableForPlanning`. First one will contain sum of all incomes - overall sum. Second one will contain sum of incomes that are set to be included in planning.

#### Additional informations

- added unit tests for new properties,
- added unit tests for `GetMonthlyBillingByYearAndMonthQuery`.

Related to #24 