### PR TITLE
#45 Feature - Allowing to close monthly billing

### DIFF
--- a/requests/MonthlyBillings/AddExpense.http
+++ b/requests/MonthlyBillings/AddExpense.http
@@ -1,7 +1,7 @@
 @host = https://localhost:7188
 
-@monthlyBillingId = f26ff0b4-a1ad-4517-b78e-2ed1c34c808f
-@planId = 5554e291-f1a3-436c-84f2-91cf9f848b8a
+@monthlyBillingId = 820db3c1-70b7-484a-b4f4-4304bb62d32a
+@planId = 102c9a20-6dc5-408a-984f-60df68e897df
 
 POST {{host}}/api/monthlyBillings/{{monthlyBillingId}}/plans/{{planId}}/expenses
 Content-Type: application/json

--- a/requests/MonthlyBillings/AddIncome.http
+++ b/requests/MonthlyBillings/AddIncome.http
@@ -1,13 +1,13 @@
 @host = https://localhost:7188
 
-@id = f26ff0b4-a1ad-4517-b78e-2ed1c34c808f
+@id = 820db3c1-70b7-484a-b4f4-4304bb62d32a
 
 POST {{host}}/api/monthlyBillings/{{id}}/incomes
 Content-Type: application/json
 
 {
-    "name": "Zwrot z zakupów",
-    "moneyAmount": 250,
+    "name": "Wypłata",
+    "moneyAmount": 7778,
     "currency": "PLN",
-    "includeInBilling": false
+    "includeInBilling": true
 }

--- a/requests/MonthlyBillings/AddPlan.http
+++ b/requests/MonthlyBillings/AddPlan.http
@@ -1,13 +1,13 @@
 @host = https://localhost:7188
 
-@id = f26ff0b4-a1ad-4517-b78e-2ed1c34c808f
+@id = 820db3c1-70b7-484a-b4f4-4304bb62d32a
 
 POST {{host}}/api/monthlyBillings/{{id}}/plans
 Content-Type: application/json
 
 {
-    "category": "Rozrywka",
-    "money": 350,
+    "category": "Test 2",
+    "money": 123.45,
     "currency": "PLN",
     "sortOrder": 5
 }

--- a/requests/MonthlyBillings/Close.http
+++ b/requests/MonthlyBillings/Close.http
@@ -1,0 +1,5 @@
+@host = https://localhost:7188
+@year = 2023
+@month = 9
+
+PUT {{host}}/api/monthlyBillings/{{year}}/{{month}}/close

--- a/requests/MonthlyBillings/Close.http
+++ b/requests/MonthlyBillings/Close.http
@@ -1,5 +1,5 @@
 @host = https://localhost:7188
 @year = 2023
-@month = 9
+@month = 10
 
 PUT {{host}}/api/monthlyBillings/{{year}}/{{month}}/close

--- a/requests/MonthlyBillings/Get.http
+++ b/requests/MonthlyBillings/Get.http
@@ -1,7 +1,7 @@
 @host = https://localhost:7188
 
 @year = 2023
-@month = 9
+@month = 12
 
 GET {{host}}/api/monthlyBillings/{{year}}/{{month}}
 Accept: application/json

--- a/requests/MonthlyBillings/Open.http
+++ b/requests/MonthlyBillings/Open.http
@@ -5,6 +5,6 @@ Content-Type: application/json
 
 {
     "Year": 2023,
-    "Month": 9,
+    "Month": 12,
     "Currency": "PLN"
 }

--- a/src/Application/MonthlyBillings/Commands/AddPlan/AddPlanCommandHandler.cs
+++ b/src/Application/MonthlyBillings/Commands/AddPlan/AddPlanCommandHandler.cs
@@ -26,13 +26,6 @@ public sealed class AddPlanCommandHandler : ICommandHandler<AddPlanCommand>
             throw new MonthlyBillingNotFoundException();
         }
 
-        if (monthlyBilling.State == State.Closed)
-        {
-            throw new MonthlyBillingAlreadyClosedException(
-                monthlyBilling.Month,
-                monthlyBilling.Year);
-        }   // TODO: Move to domain layer
-
         var plan = new Plan(
             new PlanId(Guid.NewGuid()),
             new Category(command.Category),
@@ -44,7 +37,6 @@ public sealed class AddPlanCommandHandler : ICommandHandler<AddPlanCommand>
         );
 
         monthlyBilling.AddPlan(plan);
-
         await _repository.Save(monthlyBilling);
     }
 }

--- a/src/Application/MonthlyBillings/Commands/CloseMonthlyBilling/CloseMonthlyBillingCommand.cs
+++ b/src/Application/MonthlyBillings/Commands/CloseMonthlyBilling/CloseMonthlyBillingCommand.cs
@@ -1,0 +1,8 @@
+using Application.Abstractions.CQRS;
+
+namespace Application.MonthlyBillings.Commands.CloseMonthlyBilling;
+
+public sealed record CloseMonthlyBillingCommand(
+    int Year,
+    int Month
+) : ICommand;

--- a/src/Application/MonthlyBillings/Commands/CloseMonthlyBilling/CloseMonthlyBillingCommandHandler.cs
+++ b/src/Application/MonthlyBillings/Commands/CloseMonthlyBilling/CloseMonthlyBillingCommandHandler.cs
@@ -1,0 +1,43 @@
+using Application.Abstractions.CQRS;
+using Application.Exceptions;
+using Domain.MonthlyBillings;
+using Domain.Repositories;
+
+namespace Application.MonthlyBillings.Commands.CloseMonthlyBilling;
+
+public sealed class CloseMonthlyBillingCommandHandler : ICommandHandler<CloseMonthlyBillingCommand>
+{
+    private readonly IMonthlyBillingRepository _repository;
+
+    public CloseMonthlyBillingCommandHandler(
+        IMonthlyBillingRepository repository
+    )
+    {
+        _repository = repository;
+    }
+
+    public async Task HandleAsync(
+        CloseMonthlyBillingCommand command,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var year = new Year(command.Year);
+        var month = new Month(command.Month);
+
+        var monthlyBilling = await _repository.Get(
+            year,
+            month
+        );
+
+        if (monthlyBilling is null)
+        {
+            throw new MonthlyBillingNotFoundException(
+                (ushort)year.Value,
+                (byte)month.Value
+            );
+        }
+
+        monthlyBilling.Close();
+        await _repository.Save(monthlyBilling);
+    }
+}

--- a/src/Domain/Exceptions/PlanNotUniqueException.cs
+++ b/src/Domain/Exceptions/PlanNotUniqueException.cs
@@ -7,7 +7,7 @@ public sealed class PlanCategoryNotUniqueException : SmugetException
     public PlanCategoryNotUniqueException(
         string category
     )
-        : base($"Plan's category `{category}` already exists int monthly billing.")
+        : base($"Plan's category `{category}` already exists in monthly billing.")
     {
         Category = category;
     }

--- a/src/Domain/MonthlyBillings/MonthlyBilling.cs
+++ b/src/Domain/MonthlyBillings/MonthlyBilling.cs
@@ -75,6 +75,11 @@ public sealed class MonthlyBilling
 
     public void AddIncome(Income income)
     {
+        if (State == State.Closed)
+        {
+            throw new MonthlyBillingAlreadyClosedException(Month, Year);
+        }
+
         if (income is null)
         {
             throw new IncomeIsNullException();
@@ -95,6 +100,11 @@ public sealed class MonthlyBilling
 
     public void AddPlan(Plan plan)
     {
+        if (State == State.Closed)
+        {
+            throw new MonthlyBillingAlreadyClosedException(Month, Year);
+        }
+
         if (plan is null)
         {
             throw new PlanIsNullException();
@@ -115,6 +125,11 @@ public sealed class MonthlyBilling
 
     public void AddExpense(PlanId planId, Expense expense)
     {
+        if (State == State.Closed)
+        {
+            throw new MonthlyBillingAlreadyClosedException(Month, Year);
+        }
+
         if (planId is null)
         {
             throw new PlanIdIsNullException();

--- a/src/WebAPI/MonthlyBillings/CloseMonthlyBillingRequest.cs
+++ b/src/WebAPI/MonthlyBillings/CloseMonthlyBillingRequest.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace WebAPI.MonthlyBillings;
+
+/// <summary>
+/// Informations about monthly billing you try to close.
+/// </summary>
+/// <param name="Year">Year of the monthly billing.</param>
+/// <param name="Month">Month of the monthly billing.</param>
+public sealed record CloseMonthlyBillingRequest(
+    [FromRoute(Name = "year")] ushort Year,
+    [FromRoute(Name = "month")] byte Month
+);

--- a/tests/Application.Unit.Tests/MonthlyBillings/Commands/CloseMonthlyBilling/CloseMonthlyBillingCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/Commands/CloseMonthlyBilling/CloseMonthlyBillingCommandHandlerTests.cs
@@ -1,0 +1,66 @@
+using Application.Exceptions;
+using Application.MonthlyBillings.Commands.CloseMonthlyBilling;
+using Application.Unit.Tests.MonthlyBillings.Commands.TestUtilities;
+using Application.Unit.Tests.TestUtilities;
+using Application.Unit.Tests.TestUtilities.Constants;
+using Domain.MonthlyBillings;
+using Domain.Repositories;
+
+namespace Application.Unit.Tests.MonthlyBillings.Commands.CloseMonthlyBilling;
+
+public sealed class CloseMonthlyBillingCommandHandlerTests
+{
+    private readonly IMonthlyBillingRepository _repository;
+    private readonly CloseMonthlyBillingCommandHandler _handler;
+
+    public CloseMonthlyBillingCommandHandlerTests()
+    {
+        _repository = Substitute.For<IMonthlyBillingRepository>();
+        _handler = new CloseMonthlyBillingCommandHandler(_repository);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenMonthlyBillingNotFound_ShouldThrowMonthlyBillingNotFoundException()
+    {
+        // Arrange
+        var command = CloseMonthlyBillingCommandUtilities.CreateCommand();
+
+        var closeMonthlyBilling = async () => await _handler.HandleAsync(
+            command,
+            default
+        );
+
+        // Assert
+        await Assert.ThrowsAsync<MonthlyBillingNotFoundException>(closeMonthlyBilling);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenCloseMonthlyBillingIsValid_ShouldCallSaveOnRepositoryOnce()
+    {
+        // Arrange
+        var command = CloseMonthlyBillingCommandUtilities.CreateCommand();
+
+        _repository
+            .Get(
+                new(command.Year),
+                new(command.Month)
+            )
+            .Returns(MonthlyBillingUtilities.CreateMonthlyBilling());
+
+        // Act
+        await _handler.HandleAsync(
+            command,
+            default
+        );
+
+        // Assert
+        await _repository
+            .Received(1)
+            .Save(
+                Arg.Is<MonthlyBilling>(
+                    m => m.Year == new Year(Constants.MonthlyBilling.Year)
+                      && m.Month == new Month(Constants.MonthlyBilling.Month)
+                )
+            );
+    }
+}

--- a/tests/Application.Unit.Tests/MonthlyBillings/Commands/TestUtilities/CloseMonthlyBillingCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/Commands/TestUtilities/CloseMonthlyBillingCommandUtilities.cs
@@ -1,0 +1,13 @@
+using Application.MonthlyBillings.Commands.CloseMonthlyBilling;
+using Application.Unit.Tests.TestUtilities.Constants;
+
+namespace Application.Unit.Tests.MonthlyBillings.Commands.TestUtilities;
+
+public static class CloseMonthlyBillingCommandUtilities
+{
+    public static CloseMonthlyBillingCommand CreateCommand()
+        => new(
+            Constants.MonthlyBilling.Year,
+            Constants.MonthlyBilling.Month
+        );
+}


### PR DESCRIPTION
### What?

I am adding ability to close monthly billing IF it exists and is not closed yet. \
Resource can be found under the route:

```java
[PUT] /api/monthlyBillings/{year}/{month}/close
```

Resource has two route parameters for specyfing which monthly billing user wants to close.

Added invariants for closed monthly billing - if it's closed you can't add plans, incomes and expenses.
### Why?

Closed monthly billing will be immutable. It cannot be changed unless user reopen it. \
On the front-end side closed monthly billings will be in separate tab.

### How?

I added method in `MonthlyBillingsController` named `Close()`. This method accepts request object of type `CloseMonthlyBillingRequest`. It contains two fields:
- Year -> year of the monthly billing,
- Month -> month of the monthly billing.

Values are pased to the Command handler which handles the logic of getting appropriate monthly billing and closing it (if it exists). \
If monthly billing doesn't exist application will return exception:


#### Additional informations
Example of closing monthly billing for 2023/9:

```java
PUT {{host}}/api/monthlyBillings/2023/9/close
```

will return:

```java
204 No Content
```

If we will try to close it again, application will return:

```json
{
  "reason": "Monthly billing for `9/2023` is already closed.",
  "code": "MonthlyBillingAlreadyClosed",
  "instance": "/api/monthlyBillings/2023/12/close"
}
```

- adding unit tests for application command handler,
- adding unit tests for method in controller,
- adding request example.