### PR TITLE
#47 Feature - Monthly billings reopening

### DIFF
--- a/requests/MonthlyBillings/Reopen.http
+++ b/requests/MonthlyBillings/Reopen.http
@@ -1,0 +1,5 @@
+@host = https://localhost:7188
+@year = 2022
+@month = 9
+
+PUT {{host}}/api/monthlyBillings/{{year}}/{{month}}/reopen

--- a/src/Application/MonthlyBillings/Commands/ReopenMonthlyBilling/ReopenMonthlyBillingCommand.cs
+++ b/src/Application/MonthlyBillings/Commands/ReopenMonthlyBilling/ReopenMonthlyBillingCommand.cs
@@ -1,0 +1,8 @@
+using Application.Abstractions.CQRS;
+
+namespace Application.MonthlyBillings.Commands.ReopenMonthlyBilling;
+
+public sealed record ReopenMonthlyBillingCommand(
+    ushort Year,
+    byte Month
+) : ICommand;

--- a/src/Application/MonthlyBillings/Commands/ReopenMonthlyBilling/ReopenMonthlyBillingCommandHandler.cs
+++ b/src/Application/MonthlyBillings/Commands/ReopenMonthlyBilling/ReopenMonthlyBillingCommandHandler.cs
@@ -1,0 +1,43 @@
+using Application.Abstractions.CQRS;
+using Application.Exceptions;
+using Domain.MonthlyBillings;
+using Domain.Repositories;
+
+namespace Application.MonthlyBillings.Commands.ReopenMonthlyBilling;
+
+public sealed class ReopenMonthlyBillingCommandHandler : ICommandHandler<ReopenMonthlyBillingCommand>
+{
+    private readonly IMonthlyBillingRepository _repository;
+
+    public ReopenMonthlyBillingCommandHandler(
+        IMonthlyBillingRepository repository
+    )
+    {
+        _repository = repository;
+    }
+
+    public async Task HandleAsync(
+        ReopenMonthlyBillingCommand command,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var year = new Year(command.Year);
+        var month = new Month(command.Month);
+
+        var monthlyBilling = await _repository.Get(
+            year,
+            month
+        );
+
+        if (monthlyBilling is null)
+        {
+            throw new MonthlyBillingNotFoundException(
+                (ushort)year.Value,
+                (byte)month.Value
+            );
+        }
+
+        monthlyBilling.Reopen();
+        await _repository.Save(monthlyBilling);
+    }
+}

--- a/src/Domain/Exceptions/MonthlyBillingAlreadyOpenedException.cs
+++ b/src/Domain/Exceptions/MonthlyBillingAlreadyOpenedException.cs
@@ -1,0 +1,9 @@
+using Domain.MonthlyBillings;
+
+namespace Domain.Exceptions;
+
+public sealed class MonthlyBillingAlreadyOpenedException : SmugetException
+{
+    public MonthlyBillingAlreadyOpenedException(Month month, Year year)
+        : base($"Monthly billing for `{month.Value}/{year.Value}` is already opened.") { }
+}

--- a/src/Domain/MonthlyBillings/MonthlyBilling.cs
+++ b/src/Domain/MonthlyBillings/MonthlyBilling.cs
@@ -164,4 +164,14 @@ public sealed class MonthlyBilling
 
         State = State.Closed;
     }
+
+    public void Reopen()
+    {
+        if (State == State.Open)
+        {
+            throw new MonthlyBillingAlreadyOpenedException(Month, Year);
+        }
+
+        State = State.Open;
+    }
 }

--- a/src/WebAPI/MonthlyBillings/MonthlyBillingsController.cs
+++ b/src/WebAPI/MonthlyBillings/MonthlyBillingsController.cs
@@ -4,6 +4,7 @@ using Application.MonthlyBillings.Commands.AddIncome;
 using Application.MonthlyBillings.Commands.AddPlan;
 using Application.MonthlyBillings.Commands.CloseMonthlyBilling;
 using Application.MonthlyBillings.Commands.OpenMonthlyBilling;
+using Application.MonthlyBillings.Commands.ReopenMonthlyBilling;
 using Application.MonthlyBillings.DTO;
 using Application.MonthlyBillings.Queries.GetByYearAndMonth;
 using Infrastructure.Exceptions;
@@ -25,6 +26,7 @@ public sealed class MonthlyBillingsController : ControllerBase
     private readonly ICommandHandler<AddExpenseCommand> _addExpense;
     private readonly IQueryHandler<GetMonthlyBillingByYearAndMonthQuery, MonthlyBillingDTO> _getMonthlyBilling;
     private readonly ICommandHandler<CloseMonthlyBillingCommand> _closeMonthlyBilling;
+    private readonly ICommandHandler<ReopenMonthlyBillingCommand> _reopenMonthlyBilling;
 
     public MonthlyBillingsController(
         ICommandHandler<OpenMonthlyBillingCommand> openMonthlyBilling,
@@ -32,7 +34,8 @@ public sealed class MonthlyBillingsController : ControllerBase
         ICommandHandler<AddPlanCommand> addPlan,
         ICommandHandler<AddExpenseCommand> addExpense,
         IQueryHandler<GetMonthlyBillingByYearAndMonthQuery, MonthlyBillingDTO> getMonthlyBilling,
-        ICommandHandler<CloseMonthlyBillingCommand> closeMonthlyBilling
+        ICommandHandler<CloseMonthlyBillingCommand> closeMonthlyBilling,
+        ICommandHandler<ReopenMonthlyBillingCommand> reopenMonthlyBilling
     )
     {
         _openMonthlyBilling = openMonthlyBilling;
@@ -41,6 +44,7 @@ public sealed class MonthlyBillingsController : ControllerBase
         _addExpense = addExpense;
         _getMonthlyBilling = getMonthlyBilling;
         _closeMonthlyBilling = closeMonthlyBilling;
+        _reopenMonthlyBilling = reopenMonthlyBilling;
     }
 
     /// <summary>
@@ -198,6 +202,31 @@ public sealed class MonthlyBillingsController : ControllerBase
 
         await _closeMonthlyBilling.HandleAsync(
             new CloseMonthlyBillingCommand(
+                year,
+                month
+            ),
+            token
+        );
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Reopens monthly billing for specified month in a year.
+    /// </summary>
+    [HttpPut("{year:int}/{month:int}/reopen")]
+    [ProducesResponseType(typeof(NoContentResult), Status204NoContent)]
+    [ProducesResponseType(typeof(Error), Status400BadRequest)]
+    [ProducesResponseType(typeof(Error), Status500InternalServerError)]
+    public async Task<IActionResult> Reopen(
+        [FromRoute] ReopenMonthlyBillingRequest request,
+        CancellationToken token = default
+    )
+    {
+        var (year, month) = request;
+
+        await _reopenMonthlyBilling.HandleAsync(
+            new ReopenMonthlyBillingCommand(
                 year,
                 month
             ),

--- a/src/WebAPI/MonthlyBillings/ReopenMonthlyBillingRequest.cs
+++ b/src/WebAPI/MonthlyBillings/ReopenMonthlyBillingRequest.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace WebAPI.MonthlyBillings;
+
+/// <summary>
+/// Informations about monthly billing you try to reopen.
+/// </summary>
+/// <param name="Year">Year of the monthly billing.</param>
+/// <param name="Month">Month of the monthly billing.</param>
+public sealed record ReopenMonthlyBillingRequest(
+    [FromRoute(Name = "year")] ushort Year,
+    [FromRoute(Name = "month")] byte Month
+);

--- a/tests/Application.Unit.Tests/MonthlyBillings/Commands/ReopenMonthlyBilling/ReopenMonthlyBillingCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/Commands/ReopenMonthlyBilling/ReopenMonthlyBillingCommandHandlerTests.cs
@@ -1,51 +1,54 @@
 using Application.Exceptions;
-using Application.MonthlyBillings.Commands.CloseMonthlyBilling;
+using Application.MonthlyBillings.Commands.ReopenMonthlyBilling;
 using Application.Unit.Tests.MonthlyBillings.Commands.TestUtilities;
 using Application.Unit.Tests.TestUtilities;
 using Application.Unit.Tests.TestUtilities.Constants;
 using Domain.MonthlyBillings;
 using Domain.Repositories;
 
-namespace Application.Unit.Tests.MonthlyBillings.Commands.CloseMonthlyBilling;
+namespace Application.Unit.Tests.MonthlyBillings.Commands.ReopenMonthlyBilling;
 
-public sealed class CloseMonthlyBillingCommandHandlerTests
+public sealed class ReopenMonthlyBillingCommandHandlerTests
 {
-    private readonly IMonthlyBillingRepository _repository;
-    private readonly CloseMonthlyBillingCommandHandler _handler;
 
-    public CloseMonthlyBillingCommandHandlerTests()
+    private readonly IMonthlyBillingRepository _repository;
+    private readonly ReopenMonthlyBillingCommandHandler _handler;
+
+    public ReopenMonthlyBillingCommandHandlerTests()
     {
         _repository = Substitute.For<IMonthlyBillingRepository>();
-        _handler = new CloseMonthlyBillingCommandHandler(_repository);
+        _handler = new ReopenMonthlyBillingCommandHandler(_repository);
     }
 
     [Fact]
     public async Task HandleAsync_WhenMonthlyBillingNotFound_ShouldThrowMonthlyBillingNotFoundException()
     {
         // Arrange
-        var command = CloseMonthlyBillingCommandUtilities.CreateCommand();
+        var command = ReopenMonthlyBillingCommandUtilities.CreateCommand();
 
-        var closeMonthlyBilling = async () => await _handler.HandleAsync(
+        var reopenMonthlyBilling = async () => await _handler.HandleAsync(
             command,
             default
         );
 
         // Assert
-        await Assert.ThrowsAsync<MonthlyBillingNotFoundException>(closeMonthlyBilling);
+        await Assert.ThrowsAsync<MonthlyBillingNotFoundException>(reopenMonthlyBilling);
     }
 
     [Fact]
-    public async Task HandleAsync_WhenCloseMonthlyBillingIsValid_ShouldCallSaveOnRepositoryOnce()
+    public async Task HandleAsync_WhenReopenMonthlyBillingIsValid_ShouldCallSaveOnRepositoryOnce()
     {
         // Arrange
-        var command = CloseMonthlyBillingCommandUtilities.CreateCommand();
+        var command = ReopenMonthlyBillingCommandUtilities.CreateCommand();
+        var fakeMonthlyBilling = MonthlyBillingUtilities.CreateMonthlyBilling();
+        fakeMonthlyBilling.Close();
 
         _repository
             .Get(
                 new(command.Year),
                 new(command.Month)
             )
-            .Returns(MonthlyBillingUtilities.CreateMonthlyBilling());
+            .Returns(fakeMonthlyBilling);
 
         // Act
         await _handler.HandleAsync(
@@ -60,7 +63,7 @@ public sealed class CloseMonthlyBillingCommandHandlerTests
                 Arg.Is<MonthlyBilling>(
                     m => m.Year == new Year(Constants.MonthlyBilling.Year)
                       && m.Month == new Month(Constants.MonthlyBilling.Month)
-                      && m.State == State.Closed
+                      && m.State == State.Open
                 )
             );
     }

--- a/tests/Application.Unit.Tests/MonthlyBillings/Commands/TestUtilities/ReopenMonthlyBillingCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/Commands/TestUtilities/ReopenMonthlyBillingCommandUtilities.cs
@@ -1,0 +1,13 @@
+using Application.MonthlyBillings.Commands.ReopenMonthlyBilling;
+using Application.Unit.Tests.TestUtilities.Constants;
+
+namespace Application.Unit.Tests.MonthlyBillings.Commands.TestUtilities;
+
+public static class ReopenMonthlyBillingCommandUtilities
+{
+    public static ReopenMonthlyBillingCommand CreateCommand()
+        => new(
+            Constants.MonthlyBilling.Year,
+            Constants.MonthlyBilling.Month
+        );
+}

--- a/tests/Domain.Unit.Tests/MonthlyBillings/MonthlyBillingTests.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/MonthlyBillingTests.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using Domain.Exceptions;
 using Domain.MonthlyBillings;
 using Domain.Unit.Tests.MonthlyBillings.TestUtilities;
-using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.EventHandlers;
 
 namespace Domain.Unit.Tests.MonthlyBillings;
 
@@ -684,5 +682,33 @@ public sealed class MonthlyBillingTests
 
         // Act & Assert
         Assert.Throws<MonthlyBillingAlreadyClosedException>(close);
+    }
+
+    [Fact]
+    public void Reopen_WhenCalled_ShouldChangeState()
+    {
+        // Arrange
+        var cut = MonthlyBillingUtilities.CreateMonthlyBilling();
+        cut.Close();
+
+        // Act
+        cut.Reopen();
+
+        // Assert
+        cut.State
+            .Should()
+            .Be(State.Open);
+    }
+
+    [Fact]
+    public void Reopen_WhenCalledForOpenedMonthlyBilling_ShouldThrowMonthlyBillingAlreadyOpened()
+    {
+        // Arrange
+        var cut = MonthlyBillingUtilities.CreateMonthlyBilling();
+
+        var reopen = () => cut.Reopen();
+
+        // Act & Assert
+        Assert.Throws<MonthlyBillingAlreadyOpenedException>(reopen);
     }
 }


### PR DESCRIPTION
### What?

I'm adding ability to reopen closed monthly billings. \
The resource responsible for re-opening is available under the route: \
```java
[PUT] /api/monthlyBillings/{year}/{month}/reopen
```

The resource has two route parameters for specyfing which monthly billing user tries to re-open.

On successfull request, application returns `No Content 204`. \
If user will try to reopen already opened monthly billing, application will return:

```json
{
  "reason": "Monthly billing for `9/2022` is already opened.",
  "code": "MonthlyBillingAlreadyOpened",
  "instance": "/api/monthlyBillings/2022/9/reopen"
}
```

### Why?

Re-opened monthly billing is mutable again - can be modified (adding plans, incomes, etc.).

### How?

Using TDD technic, first, I created endpoint in controller named `Reopen()`. Then I implemented `ReopenMonthlyBillingCommand()` and it's handler. At the end I implemented `Reopen()` behaviour in `MonthlyBilling` domain object.

#### Additional informations
- adding unit tests for domain method `Reopen()`,
- adding unit tests for ReopenMonthlyBillingCommandHandler`,
- adding unit tests for `Reopen()` method in `MonthlyBillingsController`,
- adding request example,
- adding Swagger documentation (XML comments).

Related to #47 