### PR TITLE
#52 Feature - Plan removing

### DIFF
--- a/requests/MonthlyBillings/RemovePlan.http
+++ b/requests/MonthlyBillings/RemovePlan.http
@@ -1,0 +1,7 @@
+@host = https://localhost:7188
+
+@monthlyBillingId = f26ff0b4-a1ad-4517-b78e-2ed1c34c808f
+@planId = cc1872a8-0fe5-46e3-91bd-5c1eebfdb97f
+
+DELETE {{host}}/api/monthlyBillings/{{monthlyBillingId}}/plans/{{planId}}
+Accept: application/json

--- a/src/Application/MonthlyBillings/Commands/RemovePlan/RemovePlanCommand.cs
+++ b/src/Application/MonthlyBillings/Commands/RemovePlan/RemovePlanCommand.cs
@@ -1,0 +1,8 @@
+using Application.Abstractions.CQRS;
+
+namespace Application.MonthlyBillings.Commands.RemovePlan;
+
+public sealed record RemovePlanCommand(
+    Guid MonthlyBillingId,
+    Guid PlanId
+) : ICommand;

--- a/src/Application/MonthlyBillings/Commands/RemovePlan/RemovePlanCommandHandler.cs
+++ b/src/Application/MonthlyBillings/Commands/RemovePlan/RemovePlanCommandHandler.cs
@@ -1,0 +1,31 @@
+using Application.Abstractions.CQRS;
+using Application.Exceptions;
+using Domain.MonthlyBillings;
+using Domain.Repositories;
+
+namespace Application.MonthlyBillings.Commands.RemovePlan;
+
+public sealed class RemovePlanCommandHandler : ICommandHandler<RemovePlanCommand>
+{
+    private readonly IMonthlyBillingRepository _repository;
+
+    public RemovePlanCommandHandler(IMonthlyBillingRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task HandleAsync(
+        RemovePlanCommand command,
+        CancellationToken cancellationToken = default
+    )
+    {
+        MonthlyBillingId monthlyBillingId = new(command.MonthlyBillingId);
+        var entity = await _repository.GetById(monthlyBillingId)
+            ?? throw new MonthlyBillingNotFoundException();
+
+        PlanId PlanId = new(command.PlanId);
+        entity.RemovePlan(PlanId);
+
+        await _repository.Save(entity);
+    }
+}

--- a/src/Domain/Exceptions/PlanNotFoundException.cs
+++ b/src/Domain/Exceptions/PlanNotFoundException.cs
@@ -6,6 +6,10 @@ public sealed class PlanNotFoundException : SmugetException
 {
     public PlanId PlanId { get; private set; }
 
+    public PlanNotFoundException()
+        : base($"Plan with passed id doesn't exist in monthly billing.")
+    {
+    }
     public PlanNotFoundException(PlanId planId)
         : base($"Plan with id = `{planId}` doesn't exists.")
     {

--- a/src/Domain/MonthlyBillings/MonthlyBilling.cs
+++ b/src/Domain/MonthlyBillings/MonthlyBilling.cs
@@ -180,6 +180,28 @@ public sealed class MonthlyBilling
         _plans.Add(plan);
     }
 
+    public void RemovePlan(
+        PlanId planId
+    )
+    {
+        // TODO: Refactor - extract method
+        if (State == State.Closed)
+        {
+            throw new MonthlyBillingAlreadyClosedException(Month, Year);
+        }
+
+        // TODO: Refactor - extract method
+        if (planId is null)
+        {
+            throw new PlanIdIsNullException();
+        }
+
+        var planToRemove = _plans?.Find(i => i.Id == planId && i.Active)
+            ?? throw new PlanNotFoundException();
+
+        planToRemove.Remove();
+    }
+
     public void AddExpense(PlanId planId, Expense expense)
     {
         // TODO: Refactor - extract method

--- a/src/Domain/MonthlyBillings/Plan.cs
+++ b/src/Domain/MonthlyBillings/Plan.cs
@@ -10,6 +10,7 @@ public sealed class Plan
     public Category Category { get; }
     public Money Money { get; }
     public uint SortOrder { get; }
+    public bool Active { get; private set; } = true;
     public IReadOnlyCollection<Expense> Expenses => _expenses.AsReadOnly();    
 
     public decimal SumOfExpenses
@@ -53,5 +54,10 @@ public sealed class Plan
     internal void AddExpense(Expense expense)
     {
         _expenses.Add(expense);
+    }
+
+    internal void Remove()
+    {
+        Active = false;
     }
 }

--- a/src/Infrastructure/Migrations/20230928173818_Add soft delete for plans.Designer.cs
+++ b/src/Infrastructure/Migrations/20230928173818_Add soft delete for plans.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistance;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(SmugetDbContext))]
-    partial class SmugetDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230928173818_Add soft delete for plans")]
+    partial class Addsoftdeleteforplans
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20230928173818_Add soft delete for plans.cs
+++ b/src/Infrastructure/Migrations/20230928173818_Add soft delete for plans.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class Addsoftdeleteforplans : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "Active",
+                table: "Plans",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Active",
+                table: "Plans");
+        }
+    }
+}

--- a/src/Infrastructure/Persistance/Configurations/PlanEntityConfiguration.cs
+++ b/src/Infrastructure/Persistance/Configurations/PlanEntityConfiguration.cs
@@ -36,6 +36,10 @@ internal sealed class PlanEntityConfiguration : IEntityTypeConfiguration<PlanEnt
             .IsRequired();
 
         builder
+            .Property(p => p.Active)
+            .IsRequired();
+
+        builder
             .HasMany(p => p.Expenses)
             .WithOne()
             .HasForeignKey(e => e.PlanId)

--- a/src/Infrastructure/Persistance/Entities/Mappings/MonthlyBillingMappingExtensions.cs
+++ b/src/Infrastructure/Persistance/Entities/Mappings/MonthlyBillingMappingExtensions.cs
@@ -17,7 +17,10 @@ internal static class MonthlyBillingMappingExtensions
             new Month(entity.Month),
             new Currency(entity.Currency),
             State.GetByName(entity.State),
-            entity.Plans.ConvertAll(
+            entity.Plans
+                .Where(p => p.Active)
+                .ToList()
+                .ConvertAll(
                 p => p.ToDomain()
             ),
             entity.Incomes

--- a/src/Infrastructure/Persistance/Entities/Mappings/PlanMappingExtensions.cs
+++ b/src/Infrastructure/Persistance/Entities/Mappings/PlanMappingExtensions.cs
@@ -35,6 +35,7 @@ internal static class PlanMappingExtensions
             MoneyCurrency = domain.Money.Currency.Value,
             SortOrder = domain.SortOrder,
             MonthlyBillingId = monthlyBillingId,
+            Active = domain.Active,
             Expenses = domain.Expenses.Select(
                 e => e.ToEntity(domain.Id.Value)
             )

--- a/src/Infrastructure/Persistance/Entities/PlanEntity.cs
+++ b/src/Infrastructure/Persistance/Entities/PlanEntity.cs
@@ -8,5 +8,6 @@ internal sealed class PlanEntity
     public string MoneyCurrency { get; set; }
     public uint SortOrder { get; set; }
     public Guid MonthlyBillingId { get; set; }
+    public bool Active { get; set; }
     public List<ExpenseEntity> Expenses { get; set; }
 }

--- a/src/WebAPI/MonthlyBillings/MonthlyBillingsController.cs
+++ b/src/WebAPI/MonthlyBillings/MonthlyBillingsController.cs
@@ -5,6 +5,7 @@ using Application.MonthlyBillings.Commands.AddPlan;
 using Application.MonthlyBillings.Commands.CloseMonthlyBilling;
 using Application.MonthlyBillings.Commands.OpenMonthlyBilling;
 using Application.MonthlyBillings.Commands.RemoveIncome;
+using Application.MonthlyBillings.Commands.RemovePlan;
 using Application.MonthlyBillings.Commands.ReopenMonthlyBilling;
 using Application.MonthlyBillings.Commands.UpdateIncome;
 using Application.MonthlyBillings.DTO;
@@ -32,6 +33,7 @@ public sealed class MonthlyBillingsController : ControllerBase
     private readonly ICommandHandler<ReopenMonthlyBillingCommand> _reopenMonthlyBilling;
     private readonly ICommandHandler<UpdateIncomeCommand> _updateIncome;
     private readonly ICommandHandler<RemoveIncomeCommand> _removeIncome;
+    private readonly ICommandHandler<RemovePlanCommand> _removePlan;
 
     public MonthlyBillingsController(
         ICommandHandler<OpenMonthlyBillingCommand> openMonthlyBilling,
@@ -42,7 +44,8 @@ public sealed class MonthlyBillingsController : ControllerBase
         ICommandHandler<CloseMonthlyBillingCommand> closeMonthlyBilling,
         ICommandHandler<ReopenMonthlyBillingCommand> reopenMonthlyBilling,
         ICommandHandler<UpdateIncomeCommand> updateIncome,
-        ICommandHandler<RemoveIncomeCommand> removeIncome
+        ICommandHandler<RemoveIncomeCommand> removeIncome,
+        ICommandHandler<RemovePlanCommand> removePlan
     )
     {
         _openMonthlyBilling = openMonthlyBilling;
@@ -54,6 +57,7 @@ public sealed class MonthlyBillingsController : ControllerBase
         _reopenMonthlyBilling = reopenMonthlyBilling;
         _updateIncome = updateIncome;
         _removeIncome = removeIncome;
+        _removePlan = removePlan;
     }
 
     /// <summary>
@@ -294,6 +298,31 @@ public sealed class MonthlyBillingsController : ControllerBase
             new RemoveIncomeCommand(
                 monthlyBillingId,
                 incomeId
+            ),
+            token
+        );
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Removes specified plan from monthly billing by plan id.
+    /// </summary>
+    [HttpDelete("{monthlyBillingId}/plans/{planId}")]
+    [ProducesResponseType(typeof(NoContentResult), Status204NoContent)]
+    [ProducesResponseType(typeof(Error), Status400BadRequest)]
+    [ProducesResponseType(typeof(Error), Status500InternalServerError)]
+    public async Task<IActionResult> RemovePlan(
+        [FromRoute] RemovePlanRequest request,
+        CancellationToken token = default
+    )
+    {
+        var (monthlyBillingId, planId) = request;
+
+        await _removePlan.HandleAsync(
+            new RemovePlanCommand(
+                monthlyBillingId,
+                planId
             ),
             token
         );

--- a/src/WebAPI/MonthlyBillings/RemovePlanRequest.cs
+++ b/src/WebAPI/MonthlyBillings/RemovePlanRequest.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace WebAPI.MonthlyBillings;
+
+/// <summary>
+/// Identificators for selecting monthly billing and plan id.
+/// </summary>
+/// <param name="MonthlyBillingId">Identifier of a monthly billing.</param>
+/// <param name="PlanId">Identifier of a plan to remove.</param>
+public sealed record RemovePlanRequest(
+    [FromRoute(Name = "monthlyBillingId")] Guid MonthlyBillingId,
+    [FromRoute(Name = "planId")] Guid PlanId
+);

--- a/tests/Application.Unit.Tests/MonthlyBillings/Commands/RemovePlan/RemovePlanCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/Commands/RemovePlan/RemovePlanCommandHandlerTests.cs
@@ -1,0 +1,95 @@
+using Application.Exceptions;
+using Application.MonthlyBillings.Commands.RemovePlan;
+using Application.Unit.Tests.MonthlyBillings.Commands.TestUtilities;
+using Application.Unit.Tests.TestUtilities;
+using Domain.MonthlyBillings;
+using Domain.Repositories;
+
+namespace Application.Unit.Tests.MonthlyBillings.Commands.RemovePlan;
+
+public sealed class RemovePlanCommandHandlerTests
+{
+    private readonly IMonthlyBillingRepository _repository;
+    private readonly RemovePlanCommandHandler _handler;
+
+    public RemovePlanCommandHandlerTests()
+    {
+        _repository = Substitute.For<IMonthlyBillingRepository>();
+        _handler = new RemovePlanCommandHandler(_repository);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenInvoked_ShouldCallGetByIdOnRepositoryOnce()
+    {
+        // Arrange
+        var command = RemovePlanCommandUtilities.CreateCommand();
+        _repository
+            .GetById(new(command.MonthlyBillingId))
+            .Returns(
+                MonthlyBillingUtilities.CreateMonthlyBilling(
+                    plans: new List<Plan>()
+                    {
+                        PlansUtilities.CreatePlan()
+                    }
+                )
+            );
+
+        // Act
+        await _handler
+            .HandleAsync(
+                command,
+                default
+            );
+
+        // Assert
+        await _repository
+            .Received(1)
+            .GetById(new(command.MonthlyBillingId));
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenMonthlyBillingDoesntExist_ShouldthrowMonthlyBillingNotFoundException()
+    {
+        // Arrange
+        var command = RemovePlanCommandUtilities.CreateCommand();
+
+        var removePlan = async () => await _handler
+            .HandleAsync(
+                command,
+                default
+            );
+
+        // Act & Assert
+        await Assert.ThrowsAsync<MonthlyBillingNotFoundException>(removePlan);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenPassedProperData_ShouldCallSaveOnRepositoryOnce()
+    {
+        // Arrange
+        var command = RemovePlanCommandUtilities.CreateCommand();
+        var fakeMonthlyBilling = MonthlyBillingUtilities.CreateMonthlyBilling(
+            plans: new List<Plan>()
+            {
+                PlansUtilities.CreatePlan()
+            }
+        );
+        _repository
+            .GetById(new(command.MonthlyBillingId))
+            .Returns(fakeMonthlyBilling);
+
+        // Act
+        await _handler
+            .HandleAsync(
+                command,
+                default
+            );
+
+        // Assert
+        await _repository
+            .Received(1)
+            .Save(Arg.Is<MonthlyBilling>(
+                m => m.Plans.Any(i => !i.Active)
+            ));
+    }
+}

--- a/tests/Application.Unit.Tests/MonthlyBillings/Commands/TestUtilities/RemovePlanCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/Commands/TestUtilities/RemovePlanCommandUtilities.cs
@@ -1,0 +1,13 @@
+using Application.MonthlyBillings.Commands.RemovePlan;
+using Application.Unit.Tests.TestUtilities.Constants;
+
+namespace Application.Unit.Tests.MonthlyBillings.Commands.TestUtilities;
+
+public static class RemovePlanCommandUtilities
+{
+    public static RemovePlanCommand CreateCommand()
+        => new(
+            Guid.NewGuid(),
+            Constants.Plan.Id
+        );
+}

--- a/tests/Application.Unit.Tests/TestUtilities/PlansUtilities.cs
+++ b/tests/Application.Unit.Tests/TestUtilities/PlansUtilities.cs
@@ -1,0 +1,17 @@
+using Domain.MonthlyBillings;
+
+namespace Application.Unit.Tests.TestUtilities;
+
+public static class PlansUtilities
+{
+    public static Plan CreatePlan()
+        => new(
+            new(Constants.Constants.Plan.Id),
+            new(Constants.Constants.Plan.Category),
+            new(
+                Constants.Constants.Plan.MoneyAmount,
+                new(Constants.Constants.Plan.Currency)
+            ),
+            1
+        );
+}

--- a/tests/Domain.Unit.Tests/MonthlyBillings/MonthlyBillingTests.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/MonthlyBillingTests.cs
@@ -590,6 +590,78 @@ public sealed class MonthlyBillingTests
     }
 
     [Fact]
+    public void RemovePlan_WhenPassedNullPlanId_ShouldThrowPlanIdIsNullException()
+    {
+        // Arrange
+        var cut = MonthlyBillingUtilities.CreateMonthlyBilling();
+
+        var removePlan = () => cut.RemovePlan(
+            null
+        );
+
+        // Act & Assert
+        Assert.Throws<PlanIdIsNullException>(removePlan);
+    }
+
+    [Fact]
+    public void RemovePlan_WhenMonthlyBillingIsClosed_ShouldThrowMonthlyBillingAlreadyClosedException()
+    {
+        // Arrange
+        var cut = MonthlyBillingUtilities.CreateMonthlyBilling();
+        cut.Close();
+
+        var removePlan = () => cut.RemovePlan(
+            new(Guid.NewGuid())
+        );
+
+        // Act & Assert
+        Assert.Throws<MonthlyBillingAlreadyClosedException>(removePlan);
+    }
+
+    [Fact]
+    public void RemovePlan_WhenPlanDoesntExistInMonthlyBilling_ShouldThrowPlanNotFoundException()
+    {
+        // Arrange
+        var cut = MonthlyBillingUtilities.CreateMonthlyBilling();
+
+        var removePlan = () => cut.RemovePlan(
+            new(Guid.NewGuid())
+        );
+
+        // Act & Assert
+        Assert.Throws<PlanNotFoundException>(removePlan);
+    }
+
+    [Fact]
+    public void RemovePlan_WhenPassedProperData_ShouldRemovePlanFromMonthlyBilling()
+    {
+        // Arrange
+        var cut = MonthlyBillingUtilities.CreateMonthlyBilling(
+            plans: new List<Plan>()
+            {
+                new Plan(
+                    Constants.Plan.Id,
+                    Constants.Plan.Category,
+                    Constants.Plan.Money,
+                    12
+                )
+            }
+        );
+
+        // Act
+        cut.RemovePlan(
+            Constants.Plan.Id
+        );
+
+        // Assert
+        cut.Plans
+            .First().Active
+                .Should()
+                .BeFalse();
+    }
+
+
+    [Fact]
     public void SumOfPlans_WhenCalled_ShouldReturnExpectedValue()
     {
         // Arrange

--- a/tests/Domain.Unit.Tests/MonthlyBillings/TestUtilities/Constants.Plan.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/TestUtilities/Constants.Plan.cs
@@ -1,3 +1,4 @@
+using System;
 using Domain.MonthlyBillings;
 
 namespace Domain.Unit.Tests.MonthlyBillings.TestUtilities;
@@ -6,6 +7,7 @@ public static partial class Constants
 {
     public static class Plan
     {
+        public static readonly PlanId Id = new(Guid.Parse("00000000-0000-0000-0000-000000000001"));
         public static readonly Category Category = new("Category");
         public static readonly Money Money = new(12.5M, new Currency("PLN"));
 

--- a/tests/WebAPI.Unit.Tests/MonthlyBillings/MonthlyBillingsControllerTests.cs
+++ b/tests/WebAPI.Unit.Tests/MonthlyBillings/MonthlyBillingsControllerTests.cs
@@ -8,6 +8,7 @@ using Application.MonthlyBillings.Commands.AddPlan;
 using Application.MonthlyBillings.Commands.CloseMonthlyBilling;
 using Application.MonthlyBillings.Commands.OpenMonthlyBilling;
 using Application.MonthlyBillings.Commands.RemoveIncome;
+using Application.MonthlyBillings.Commands.RemovePlan;
 using Application.MonthlyBillings.Commands.ReopenMonthlyBilling;
 using Application.MonthlyBillings.Commands.UpdateIncome;
 using Application.MonthlyBillings.DTO;
@@ -31,6 +32,7 @@ public sealed class MonthlyBillingsControllerTests
     private readonly Mock<ICommandHandler<ReopenMonthlyBillingCommand>> _mockReopenMonthlyBillingCommandHandler;
     private readonly Mock<ICommandHandler<UpdateIncomeCommand>> _mockUpdateIncomeCommandHandler;
     private readonly Mock<ICommandHandler<RemoveIncomeCommand>> _mockRemoveIncomeCommandHandler;
+    private readonly Mock<ICommandHandler<RemovePlanCommand>> _mockRemovePlanCommandHandler;
 
     public MonthlyBillingsControllerTests()
     {
@@ -43,6 +45,7 @@ public sealed class MonthlyBillingsControllerTests
         _mockReopenMonthlyBillingCommandHandler = new Mock<ICommandHandler<ReopenMonthlyBillingCommand>>();
         _mockUpdateIncomeCommandHandler = new Mock<ICommandHandler<UpdateIncomeCommand>>();
         _mockRemoveIncomeCommandHandler = new Mock<ICommandHandler<RemoveIncomeCommand>>();
+        _mockRemovePlanCommandHandler = new Mock<ICommandHandler<RemovePlanCommand>>();
 
         _mockGetMonthlyBillingQueryHandler
             .Setup(m => m.HandleAsync(
@@ -63,7 +66,8 @@ public sealed class MonthlyBillingsControllerTests
             _mockCloseMonthlyBillingCommandHandler.Object,
             _mockReopenMonthlyBillingCommandHandler.Object,
             _mockUpdateIncomeCommandHandler.Object,
-            _mockRemoveIncomeCommandHandler.Object
+            _mockRemoveIncomeCommandHandler.Object,
+            _mockRemovePlanCommandHandler.Object
         );
     }
 
@@ -794,6 +798,65 @@ public sealed class MonthlyBillingsControllerTests
         _mockRemoveIncomeCommandHandler.Verify(
             m => m.HandleAsync(
                 It.IsAny<RemoveIncomeCommand>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RemovePlan_OnSuccess_ShouldReturnNoContentResult()
+    {
+        // Arrange
+        var request = new RemovePlanRequest(
+                Guid.NewGuid(),
+                Guid.NewGuid()
+        );
+
+        // Act
+        var result = await _cut.RemovePlan(request);
+
+        // Assert
+        result
+            .Should()
+            .NotBeNull();
+
+        result
+            .Should()
+            .BeOfType<NoContentResult>();
+    }
+
+    [Fact]
+    public async Task RemovePlan_OnSuccess_ShouldReturn204StatusCode()
+    {
+        // Arrange
+        var request = new RemovePlanRequest(
+                Guid.NewGuid(),
+                Guid.NewGuid()
+        );
+
+        // Act
+        var result = (NoContentResult)await _cut.RemovePlan(request);
+
+        // Assert
+        result.StatusCode
+            .Should()
+            .Be(204);
+    }
+
+    [Fact]
+    public async Task RemovePlan_WhenInvoked_ShouldCallRemovePlanCommandHandler()
+    {
+        // Act
+        await _cut.RemovePlan(
+            new(
+                Guid.NewGuid(),
+                Guid.NewGuid()
+            )
+        );
+
+        // Assert
+        _mockRemovePlanCommandHandler.Verify(
+            m => m.HandleAsync(
+                It.IsAny<RemovePlanCommand>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }


### PR DESCRIPTION
### What?

I'm adding ability to remove plan from monthly billings. \
To remove plan from monthly billing user can use resource under the route:

```java
[DELETE] /api/monthlyBillings/{monthlyBillingId}/plans/{planId}
```

This resource has two required path parameters:
- monthlyBillingId -> monthly billing identifier,
- planId -> plan identifier.

Plan can be removed only when monthly billing is not closed and plan does exist.

In case of successfull operation of removing, applications returns:

```java
204 No Content
```

In case of error due to closed monthly billing, application returns:

```json
{
  "reason": "Monthly billing for `9/2023` is already closed.",
  "code": "MonthlyBillingAlreadyClosed",
  "instance": "/api/monthlyBillings/f26ff0b4-a1ad-4517-b78e-2ed1c34c808f/plans/a206e5e4-4e3c-4df0-9023-88d3d59bbe0b"
}
```

When plan doesn't exist:

```json
{
  "reason": "Plan with passed id doesn't exist in monthly billing.",
  "code": "PlanNotFound",
  "instance": "/api/monthlyBillings/f26ff0b4-a1ad-4517-b78e-2ed1c34c808f/plans/820db3c1-70b7-484a-b4f4-4304bb62d32a"
}
```

###  Why?

Application must allow users to edit their plans - in case of a mistake.

### How?

Using TDD technic I added domain logic for removing (soft delete) plan from aggregate. \
Then I added command with it's handler. \
At the end I added method in `MonthlyBillingsController`.

#### Additional informations
- added unit tests for domain methods,
- added unit tests for command and it's handler,
- added unit tests for controller method,
- added Swagger documentation,
- added http request example.

Related to #52