### PR TITLE
#43 Feature - Plans editing

### DIFF
--- a/requests/MonthlyBillings/UpdatePlan.http
+++ b/requests/MonthlyBillings/UpdatePlan.http
@@ -1,0 +1,14 @@
+@host = https://localhost:7188
+
+@monthlyBillingId = 2330a403-64e8-4325-b38c-cb229e2ba9b2
+@planId = a3d2fc36-0d6f-4424-9b4d-af3979b3fc4b
+
+PUT {{host}}/api/monthlyBillings/{{monthlyBillingId}}/plans/{{planId}}
+Content-Type: application/json
+
+{
+    "category": "Żywność",
+    "moneyAmount": 321.54,
+    "currency": "PLN",
+    "sortOrder": 12
+}

--- a/src/Application/MonthlyBillings/Commands/UpdatePlan/UpdatePlanCommand.cs
+++ b/src/Application/MonthlyBillings/Commands/UpdatePlan/UpdatePlanCommand.cs
@@ -1,0 +1,12 @@
+using Application.Abstractions.CQRS;
+
+namespace Application.MonthlyBillings.Commands.UpdatePlan;
+
+public sealed record UpdatePlanCommand(
+    Guid MonthlyBillingId,
+    Guid PlanId,
+    string Category,
+    decimal MoneyAmount,
+    string Currency,
+    uint SortOrder
+) : ICommand;

--- a/src/Application/MonthlyBillings/Commands/UpdatePlan/UpdatePlanCommandHandler.cs
+++ b/src/Application/MonthlyBillings/Commands/UpdatePlan/UpdatePlanCommandHandler.cs
@@ -1,0 +1,32 @@
+using Application.Abstractions.CQRS;
+using Application.Exceptions;
+using Domain.MonthlyBillings;
+using Domain.Repositories;
+
+namespace Application.MonthlyBillings.Commands.UpdatePlan;
+
+public sealed class UpdatePlanCommandHandler : ICommandHandler<UpdatePlanCommand>
+{
+    private readonly IMonthlyBillingRepository _repository;
+
+    public UpdatePlanCommandHandler(IMonthlyBillingRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task HandleAsync(UpdatePlanCommand command, CancellationToken cancellationToken = default)
+    {
+        MonthlyBillingId monthlyBillingId = new(command.MonthlyBillingId);
+        var entity = await _repository.GetById(monthlyBillingId)
+            ?? throw new MonthlyBillingNotFoundException();
+
+        entity.UpdatePlan(
+            new(command.PlanId),
+            new(command.Category),
+            new(command.MoneyAmount, new(command.Currency)),
+            command.SortOrder
+        );
+
+        await _repository.Save(entity);
+    }
+}

--- a/src/Domain/MonthlyBillings/MonthlyBilling.cs
+++ b/src/Domain/MonthlyBillings/MonthlyBilling.cs
@@ -180,6 +180,33 @@ public sealed class MonthlyBilling
         _plans.Add(plan);
     }
 
+    public void UpdatePlan(
+        PlanId planId,
+        Category category,
+        Money money,
+        uint sortOrder
+    )
+    {
+        if (State == State.Closed)
+        {
+            throw new MonthlyBillingAlreadyClosedException(Month, Year);
+        }
+
+        if (planId is null)
+        {
+            throw new PlanIdIsNullException();
+        }
+
+        var planToUpdate = _plans?.Find(p => p.Id == planId && p.Active)
+            ?? throw new PlanNotFoundException();
+
+        planToUpdate.Update(
+            category,
+            money,
+            sortOrder
+        );
+    }
+
     public void RemovePlan(
         PlanId planId
     )

--- a/src/Domain/MonthlyBillings/Plan.cs
+++ b/src/Domain/MonthlyBillings/Plan.cs
@@ -7,11 +7,11 @@ namespace Domain.MonthlyBillings;
 public sealed class Plan
 {
     public PlanId Id { get; } = new PlanId(Guid.NewGuid());
-    public Category Category { get; }
-    public Money Money { get; }
-    public uint SortOrder { get; }
+    public Category Category { get; private set; }
+    public Money Money { get; private set; }
+    public uint SortOrder { get; private set; }
     public bool Active { get; private set; } = true;
-    public IReadOnlyCollection<Expense> Expenses => _expenses.AsReadOnly();    
+    public IReadOnlyCollection<Expense> Expenses => _expenses.AsReadOnly();
 
     public decimal SumOfExpenses
         => _expenses?.Sum(e => e.Money.Amount) ?? 0m;
@@ -26,6 +26,7 @@ public sealed class Plan
         List<Expense> expenses = null
     )
     {
+        // TODO: Refactor - extract method
         if (planId is null)
         {
             throw new PlanIdIsNullException();
@@ -33,6 +34,7 @@ public sealed class Plan
 
         Id = planId;
 
+        // TODO: Refactor - extract method
         if (category is null)
         {
             throw new CategoryIsNullException();
@@ -40,6 +42,7 @@ public sealed class Plan
 
         Category = category;
 
+        // TODO: Refactor - extract method
         if (money is null)
         {
             throw new MoneyIsNullException();
@@ -54,6 +57,29 @@ public sealed class Plan
     internal void AddExpense(Expense expense)
     {
         _expenses.Add(expense);
+    }
+
+    internal void Update(
+        Category category,
+        Money money,
+        uint sortOrder
+    )
+    {
+        // TODO: Refactor - extract method
+        if (category is null)
+        {
+            throw new CategoryIsNullException();
+        }
+
+        // TODO: Refactor - extract method
+        if (money is null)
+        {
+            throw new MoneyIsNullException();
+        }
+
+        Category = category;
+        Money = money;
+        SortOrder = sortOrder;
     }
 
     internal void Remove()

--- a/src/WebAPI/MonthlyBillings/MonthlyBillingsController.cs
+++ b/src/WebAPI/MonthlyBillings/MonthlyBillingsController.cs
@@ -8,6 +8,7 @@ using Application.MonthlyBillings.Commands.RemoveIncome;
 using Application.MonthlyBillings.Commands.RemovePlan;
 using Application.MonthlyBillings.Commands.ReopenMonthlyBilling;
 using Application.MonthlyBillings.Commands.UpdateIncome;
+using Application.MonthlyBillings.Commands.UpdatePlan;
 using Application.MonthlyBillings.DTO;
 using Application.MonthlyBillings.Queries.GetByYearAndMonth;
 using Infrastructure.Exceptions;
@@ -34,6 +35,7 @@ public sealed class MonthlyBillingsController : ControllerBase
     private readonly ICommandHandler<UpdateIncomeCommand> _updateIncome;
     private readonly ICommandHandler<RemoveIncomeCommand> _removeIncome;
     private readonly ICommandHandler<RemovePlanCommand> _removePlan;
+    private readonly ICommandHandler<UpdatePlanCommand> _updatePlan;
 
     public MonthlyBillingsController(
         ICommandHandler<OpenMonthlyBillingCommand> openMonthlyBilling,
@@ -45,7 +47,8 @@ public sealed class MonthlyBillingsController : ControllerBase
         ICommandHandler<ReopenMonthlyBillingCommand> reopenMonthlyBilling,
         ICommandHandler<UpdateIncomeCommand> updateIncome,
         ICommandHandler<RemoveIncomeCommand> removeIncome,
-        ICommandHandler<RemovePlanCommand> removePlan
+        ICommandHandler<RemovePlanCommand> removePlan,
+        ICommandHandler<UpdatePlanCommand> updatePlan
     )
     {
         _openMonthlyBilling = openMonthlyBilling;
@@ -58,6 +61,7 @@ public sealed class MonthlyBillingsController : ControllerBase
         _updateIncome = updateIncome;
         _removeIncome = removeIncome;
         _removePlan = removePlan;
+        _updatePlan = updatePlan;
     }
 
     /// <summary>
@@ -323,6 +327,37 @@ public sealed class MonthlyBillingsController : ControllerBase
             new RemovePlanCommand(
                 monthlyBillingId,
                 planId
+            ),
+            token
+        );
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Updates specified plan in monthly billing.
+    /// </summary>
+    [HttpPut("{monthlyBillingId}/plans/{planId}")]
+    [ProducesResponseType(typeof(NoContentResult), Status204NoContent)]
+    [ProducesResponseType(typeof(Error), Status400BadRequest)]
+    [ProducesResponseType(typeof(Error), Status500InternalServerError)]
+    public async Task<IActionResult> UpdatePlan(
+        [FromRoute(Name = "monthlyBillingId")] Guid monthlyBillingId,
+        [FromRoute(Name = "planId")] Guid planId,
+        [FromBody] UpdatePlanRequest request,
+        CancellationToken token = default
+    )
+    {
+        var (category, moneyAmount, currency, sortOrder) = request;
+
+        await _updatePlan.HandleAsync(
+            new UpdatePlanCommand(
+                monthlyBillingId,
+                planId,
+                category,
+                moneyAmount,
+                currency,
+                sortOrder
             ),
             token
         );

--- a/src/WebAPI/MonthlyBillings/UpdatePlanRequest.cs
+++ b/src/WebAPI/MonthlyBillings/UpdatePlanRequest.cs
@@ -1,0 +1,15 @@
+namespace WebAPI.MonthlyBillings;
+
+/// <summary>
+/// Updated values for plan in monthly billing.
+/// </summary>
+/// <param name="Category">New category name for plan.</param>
+/// <param name="MoneyAmount">Updated value of money amount.</param>
+/// <param name="Currency">New currency for money.</param>
+/// <param name="SortOrder">New sort order value.</param>
+public sealed record UpdatePlanRequest(
+    string Category,
+    decimal MoneyAmount,
+    string Currency,
+    uint SortOrder
+);

--- a/tests/Application.Unit.Tests/MonthlyBillings/Commands/TestUtilities/UpdatePlanCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/Commands/TestUtilities/UpdatePlanCommandUtilities.cs
@@ -1,0 +1,17 @@
+using Application.MonthlyBillings.Commands.UpdatePlan;
+using Application.Unit.Tests.TestUtilities.Constants;
+
+namespace Application.Unit.Tests.MonthlyBillings.Commands.TestUtilities;
+
+public static class UpdatePlanCommandUtilities
+{
+    public static UpdatePlanCommand CreateCommand()
+        => new(
+            Constants.MonthlyBilling.Id,
+            Constants.Plan.Id,
+            "Updated Category",
+            258.96m,
+            "EUR",
+            99
+        );
+}

--- a/tests/Application.Unit.Tests/MonthlyBillings/Commands/UpdatePlan/UpdatePlanCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/Commands/UpdatePlan/UpdatePlanCommandHandlerTests.cs
@@ -1,0 +1,89 @@
+using Application.Exceptions;
+using Application.MonthlyBillings.Commands.UpdatePlan;
+using Application.Unit.Tests.MonthlyBillings.Commands.TestUtilities;
+using Application.Unit.Tests.TestUtilities;
+using Application.Unit.Tests.TestUtilities.Constants;
+using Domain.MonthlyBillings;
+using Domain.Repositories;
+
+namespace Application.Unit.Tests.MonthlyBillings.Commands.UpdatePlan;
+
+public sealed class UpdatePlanCommandHandlerTests
+{
+    private readonly IMonthlyBillingRepository _repository;
+    private readonly UpdatePlanCommandHandler _handler;
+
+    public UpdatePlanCommandHandlerTests()
+    {
+        _repository = Substitute.For<IMonthlyBillingRepository>();
+        _handler = new UpdatePlanCommandHandler(_repository);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenInvoked_ShouldCallGetByIdOnRepositoryOnce()
+    {
+        // Arrange
+        var command = UpdatePlanCommandUtilities.CreateCommand();
+        _repository
+            .GetById(new(command.MonthlyBillingId))
+            .Returns(MonthlyBillingUtilities.CreateMonthlyBilling());
+
+        // Act
+        await _handler.HandleAsync(
+            command,
+            default
+        );
+
+        // Assert
+        await _repository
+            .Received(1)
+            .GetById(new(command.MonthlyBillingId));
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenCalledForNotExistingMonthlyBilling_ShouldThrowMonthlyBillingNotFoundException()
+    {
+        // Arrange
+        var command = UpdatePlanCommandUtilities.CreateCommand();
+
+        var updatePlan = async () => await _handler
+            .HandleAsync(
+                command,
+                default
+            );
+
+        // Act & Assert
+        await Assert.ThrowsAsync<MonthlyBillingNotFoundException>(updatePlan);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenPassedProperData_ShouldCallSaveOnRepositoryOnce()
+    {
+        // Arrange
+        var command = UpdatePlanCommandUtilities.CreateCommand();
+        _repository
+            .GetById(new(command.MonthlyBillingId))
+            .Returns(MonthlyBillingUtilities.CreateMonthlyBilling(
+                plans: new List<Plan>() { PlansUtilities.CreatePlan() }
+            ));
+
+        // Act
+        await _handler.HandleAsync(
+            command,
+            default
+        );
+
+        // Assert
+        await _repository
+            .Received(1)
+            .Save(Arg.Is<MonthlyBilling>(
+                m => m.Plans.Any(
+                    p => p.Id.Value == command.PlanId
+                      && p.Category.Value == "Updated Category"
+                      && p.Money.Amount == 258.96m
+                      && p.Money.Currency.Value == "EUR"
+                      && p.SortOrder == 99
+                )
+            ));
+    }
+}

--- a/tests/Application.Unit.Tests/MonthlyBillings/Commands/UpdatePlan/UpdatePlanCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/Commands/UpdatePlan/UpdatePlanCommandHandlerTests.cs
@@ -26,7 +26,9 @@ public sealed class UpdatePlanCommandHandlerTests
         var command = UpdatePlanCommandUtilities.CreateCommand();
         _repository
             .GetById(new(command.MonthlyBillingId))
-            .Returns(MonthlyBillingUtilities.CreateMonthlyBilling());
+            .Returns(MonthlyBillingUtilities.CreateMonthlyBilling(
+                plans: new List<Plan>() { PlansUtilities.CreatePlan() }
+            ));
 
         // Act
         await _handler.HandleAsync(

--- a/tests/Domain.Unit.Tests/MonthlyBillings/MonthlyBillingTests.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/MonthlyBillingTests.cs
@@ -590,6 +590,108 @@ public sealed class MonthlyBillingTests
     }
 
     [Fact]
+    public void UpdatePlan_WhenMonthlyBillingIsClosed_ShouldThrowMonthlyBillingAlreadyClosedException()
+    {
+        // Arrange
+        var cut = MonthlyBillingUtilities.CreateMonthlyBilling();
+        cut.Close();
+
+        var updatePlan = () => cut.UpdatePlan(
+            new(Guid.NewGuid()),
+            new Category("Updated Plan Category"),
+            new Money(
+                546.43m,
+                new Currency("USD")
+            ),
+            12
+        );
+
+        // Act & Assert
+        Assert.Throws<MonthlyBillingAlreadyClosedException>(updatePlan);
+    }
+
+    [Fact]
+    public void UpdatePlan_WhenPlanIdIsNull_ShouldThrowPlanIdIsNullException()
+    {
+        // Arrange
+        var cut = MonthlyBillingUtilities.CreateMonthlyBilling();
+
+        var updatePlan = () => cut.UpdatePlan(
+            null,
+            new Category("Updated Plan Category"),
+            new Money(
+                546.43m,
+                new Currency("USD")
+            ),
+            12
+        );
+
+        // Act & Assert
+        Assert.Throws<PlanIdIsNullException>(updatePlan);
+    }
+
+    [Fact]
+    public void UpdatePlan_WhenPlanDoesntExistInMonthlyBilling_ShouldThrowPlanNotFoundException()
+    {
+        // Arrange
+        var cut = MonthlyBillingUtilities.CreateMonthlyBilling(
+            plans: new List<Plan>()
+        );
+
+        var updatePlan = () => cut.UpdatePlan(
+            new(Guid.NewGuid()),
+            new Category("Updated Plan Category"),
+            new Money(
+                546.43m,
+                new Currency("USD")
+            ),
+            12
+        );
+        
+        // Act & Assert
+        Assert.Throws<PlanNotFoundException>(updatePlan);
+    }
+
+    [Fact]
+    public void UpdatePlan_WhenPassedProperData_ShouldUpdatePlan()
+    {
+        // Arrange
+        var cut = MonthlyBillingUtilities.CreateMonthlyBilling(
+            plans: new List<Plan>()
+            { 
+                new Plan(
+                    Constants.Plan.Id,
+                    Constants.Plan.Category,
+                    Constants.Plan.Money,
+                    1
+                )
+            }
+        );
+
+        // Act
+        cut.UpdatePlan(
+            Constants.Plan.Id,
+            new Category("Updated Plan Category"),
+            new Money(
+                546.43m,
+                new Currency("USD")
+            ),
+            12
+        );
+
+        //Assert
+        var firstPlan = cut.Plans.First();
+        firstPlan
+            .Should()
+            .Match<Plan>(
+                p => p.Category.Value == "Updated Plan Category"
+                  && p.Money.Amount == 546.43m
+                  && p.Money.Currency.Value == "USD"
+                  && p.SortOrder == 12
+            );
+    }
+
+    [Fact]
     public void RemovePlan_WhenPassedNullPlanId_ShouldThrowPlanIdIsNullException()
     {
         // Arrange

--- a/tests/Domain.Unit.Tests/MonthlyBillings/PlanTests.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/PlanTests.cs
@@ -123,6 +123,103 @@ public sealed class PlanTest
     }
 
     [Fact]
+    public void Update_WhenPassedNullCategory_ShouldThrowCategoryIsNullException()
+    {
+        // Arrange
+        var cut = new Plan(
+            Constants.Plan.Id,
+            Constants.Plan.Category,
+            Constants.Plan.Money,
+            1
+        );
+
+        var updatePlan = () => cut.Update(
+            null,
+            new Money(
+                123.45m,
+                new Currency("USD")
+            ),
+            2
+        );
+
+        // Act & Assert
+        Assert.Throws<CategoryIsNullException>(updatePlan);
+    }
+
+    [Fact]
+    public void Update_WhenPassedNullMoney_ShouldThrowMoneyIsNullException()
+    {
+        // Arrange
+        var cut = new Plan(
+            Constants.Plan.Id,
+            Constants.Plan.Category,
+            Constants.Plan.Money,
+            1
+        );
+
+        var updatePlan = () => cut.Update(
+            new Category("Updated Category for plan"),
+            null,
+            5
+        );
+
+        // Act & Assert
+        Assert.Throws<MoneyIsNullException>(updatePlan);
+    }
+
+    [Fact]
+    public void Update_WhenPassedProperData_ShouldUpdatePlan()
+    {
+        // Arrange
+        var cut = new Plan(
+            Constants.Plan.Id,
+            Constants.Plan.Category,
+            Constants.Plan.Money,
+            1
+        );
+
+        // Act
+        cut.Update(
+            new Category("Updated Category for plan"),
+            new Money(
+                123.45m,
+                new Currency("USD")
+            ),
+            5
+        );
+
+        // Assert
+        cut
+            .Should()
+            .Match<Plan>(
+                p => p.Category.Value == "Updated Category for plan"
+                  && p.Money.Amount == 123.45m
+                  && p.Money.Currency.Value == "USD"
+                  && p.SortOrder == 5
+            );
+    }
+
+    [Fact]
+    public void Remove_WhenCalled_ShouldSetActiveToFalse()
+    {
+        // Arrange
+        var cut = new Plan(
+            Constants.Plan.Id,
+            Constants.Plan.Category,
+            Constants.Plan.Money,
+            1
+        );
+
+        // Act
+        cut.Remove();
+
+        // Assert
+        cut.Active
+            .Should()
+            .BeFalse();
+    }
+
+    [Fact]
     public void SumOfExpense_WhenCalled_ShouldReturnExpectedValue()
     {
         // Arrange

--- a/tests/WebAPI.Unit.Tests/MonthlyBillings/MonthlyBillingsControllerTests.cs
+++ b/tests/WebAPI.Unit.Tests/MonthlyBillings/MonthlyBillingsControllerTests.cs
@@ -11,6 +11,7 @@ using Application.MonthlyBillings.Commands.RemoveIncome;
 using Application.MonthlyBillings.Commands.RemovePlan;
 using Application.MonthlyBillings.Commands.ReopenMonthlyBilling;
 using Application.MonthlyBillings.Commands.UpdateIncome;
+using Application.MonthlyBillings.Commands.UpdatePlan;
 using Application.MonthlyBillings.DTO;
 using Application.MonthlyBillings.Queries.GetByYearAndMonth;
 using Microsoft.AspNetCore.Mvc;
@@ -33,6 +34,7 @@ public sealed class MonthlyBillingsControllerTests
     private readonly Mock<ICommandHandler<UpdateIncomeCommand>> _mockUpdateIncomeCommandHandler;
     private readonly Mock<ICommandHandler<RemoveIncomeCommand>> _mockRemoveIncomeCommandHandler;
     private readonly Mock<ICommandHandler<RemovePlanCommand>> _mockRemovePlanCommandHandler;
+    private readonly Mock<ICommandHandler<UpdatePlanCommand>> _mockUpdatePlanCommandHandler;
 
     public MonthlyBillingsControllerTests()
     {
@@ -46,6 +48,7 @@ public sealed class MonthlyBillingsControllerTests
         _mockUpdateIncomeCommandHandler = new Mock<ICommandHandler<UpdateIncomeCommand>>();
         _mockRemoveIncomeCommandHandler = new Mock<ICommandHandler<RemoveIncomeCommand>>();
         _mockRemovePlanCommandHandler = new Mock<ICommandHandler<RemovePlanCommand>>();
+        _mockUpdatePlanCommandHandler = new Mock<ICommandHandler<UpdatePlanCommand>>();
 
         _mockGetMonthlyBillingQueryHandler
             .Setup(m => m.HandleAsync(
@@ -67,7 +70,8 @@ public sealed class MonthlyBillingsControllerTests
             _mockReopenMonthlyBillingCommandHandler.Object,
             _mockUpdateIncomeCommandHandler.Object,
             _mockRemoveIncomeCommandHandler.Object,
-            _mockRemovePlanCommandHandler.Object
+            _mockRemovePlanCommandHandler.Object,
+            _mockUpdatePlanCommandHandler.Object
         );
     }
 
@@ -700,7 +704,7 @@ public sealed class MonthlyBillingsControllerTests
     }
 
     [Fact]
-    public async Task Open_OnSuccess_ShouldReturnStatusCode204()
+    public async Task UpdateIncome_OnSuccess_ShouldReturnStatusCode204()
     {
         // Act
         var result = (NoContentResult)await _cut.UpdateIncome(
@@ -857,6 +861,75 @@ public sealed class MonthlyBillingsControllerTests
         _mockRemovePlanCommandHandler.Verify(
             m => m.HandleAsync(
                 It.IsAny<RemovePlanCommand>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdatePlan_OnSuccess_ShouldReturnNoContentResult()
+    {
+        // Act
+        var result = await _cut.UpdatePlan(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            new(
+                "Updated Category",
+                11.24m,
+                "USD",
+                1
+            )
+        );
+
+        // Assert
+        result
+            .Should()
+            .NotBeNull();
+
+        result
+            .Should()
+            .BeOfType<NoContentResult>();
+    }
+
+    [Fact]
+    public async Task UpdatePlan_OnSuccess_ShouldReturnStatusCode204()
+    {
+        // Act
+        var result = (NoContentResult)await _cut.UpdatePlan(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            new(
+                "Updated Category",
+                11.24m,
+                "USD",
+                12
+            )
+        );
+
+        // Assert
+        result.StatusCode
+            .Should()
+            .Be(204);
+    }
+
+    [Fact]
+    public async Task UpdatePlan_WhenInvoked_ShouldCallUpdatePlanCommandHandler()
+    {
+        // Act
+        await _cut.UpdatePlan(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            new(
+                "Updated name",
+                11.24m,
+                "USD",
+                85
+            )
+        );
+
+        // Assert
+        _mockUpdatePlanCommandHandler.Verify(
+            m => m.HandleAsync(
+                It.IsAny<UpdatePlanCommand>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }


### PR DESCRIPTION
### What?

I'm adding ability to edit plans in monthly billing. \
Monthly billing have to be opened and plan have to exist in specified monthly billing.

Edit can be done using resource:

```java
[PUT] /api/monthlybillings/{monthlyBillingId}/plans/{planId}
```

### Why?

Application should allow users to change their planning.

### How?

Using TDD technic I created logic in domain layer. Then I created command with it's handler. At the end I added method to the controller.

#### Additional informations
- added unit tests for domain methods logic,
- added unit tests for command handler,
- added unit tests for method in controller,
- added Swagger documentation comments.

Related to #43 