### PR TITLE
#57 - Unit tests improvements

### DIFF
--- a/src/Application/MonthlyBillings/ExpenseDTO.cs
+++ b/src/Application/MonthlyBillings/ExpenseDTO.cs
@@ -2,7 +2,7 @@ namespace Application.MonthlyBillings;
 
 public sealed class ExpenseDTO
 {
-    public string Id { get; set; }
+    public Guid Id { get; set; }
     public string Money { get; set; }
     public DateTimeOffset ExpenseDate { get; set; }
     public string Description { get; set; }

--- a/src/Application/MonthlyBillings/GetByYearAndMonth/GetMonthlyBillingByYearAndMonthQueryHandler.cs
+++ b/src/Application/MonthlyBillings/GetByYearAndMonth/GetMonthlyBillingByYearAndMonthQueryHandler.cs
@@ -7,6 +7,7 @@ using Domain.Repositories;
 
 namespace Application.MonthlyBillings.GetByYearAndMonth;
 
+// TODO: Read model (CQRS) - implement faster data reading
 public sealed class GetMonthlyBillingByYearAndMonthQueryHandler : IQueryHandler<GetMonthlyBillingByYearAndMonthQuery, MonthlyBillingDTO>
 {
     private readonly IMonthlyBillingRepository _repository;

--- a/src/Application/MonthlyBillings/GetByYearAndMonth/GetMonthlyBillingByYearAndMonthQueryHandler.cs
+++ b/src/Application/MonthlyBillings/GetByYearAndMonth/GetMonthlyBillingByYearAndMonthQueryHandler.cs
@@ -1,6 +1,5 @@
 using Application.Abstractions.CQRS;
 using Application.Exceptions;
-using Application.MonthlyBillings;
 using Application.MonthlyBillings.Mappings;
 using Domain.MonthlyBillings;
 using Domain.Repositories;

--- a/src/Application/MonthlyBillings/IncomeDTO.cs
+++ b/src/Application/MonthlyBillings/IncomeDTO.cs
@@ -6,5 +6,4 @@ public sealed class IncomeDTO
     public string Name { get; set; }
     public string Money { get; set; }
     public bool Include { get; set; }
-    public bool Active { get; set; }
 }

--- a/src/Application/MonthlyBillings/Mappings/ExpenseMappings.cs
+++ b/src/Application/MonthlyBillings/Mappings/ExpenseMappings.cs
@@ -13,7 +13,7 @@ public static class ExpenseMappings
 
         return new ExpenseDTO()
         {
-            Id = domain.Id.Value.ToString(),
+            Id = domain.Id.Value,
             Money = domain.Money.ToString(),
             ExpenseDate = domain.ExpenseDate,
             Description = domain.Description

--- a/src/Application/MonthlyBillings/Mappings/IncomeMappings.cs
+++ b/src/Application/MonthlyBillings/Mappings/IncomeMappings.cs
@@ -16,8 +16,7 @@ public static class IncomeMappings
             Id = domain.Id.Value,
             Name = domain.Name.Value,
             Money = domain.Money.ToString(),
-            Include = domain.Include,
-            Active = domain.Active
+            Include = domain.Include
         };
     }
 }

--- a/src/Application/MonthlyBillings/Mappings/MonthlyBillingMappings.cs
+++ b/src/Application/MonthlyBillings/Mappings/MonthlyBillingMappings.cs
@@ -13,7 +13,7 @@ public static class MonthlyBillingMappingsExtension
 
         return new MonthlyBillingDTO()
         {
-            Id = domain.Id.Value.ToString(),
+            Id = domain.Id.Value,
             Year = domain.Year.Value,
             Month = domain.Month.Value,
             State = domain.State.ToString(),

--- a/src/Application/MonthlyBillings/Mappings/PlanMappings.cs
+++ b/src/Application/MonthlyBillings/Mappings/PlanMappings.cs
@@ -13,7 +13,7 @@ public static class PlanMappings
 
         return new PlanDTO()
         {
-            Id = domain.Id.Value.ToString(),
+            Id = domain.Id.Value,
             Category = domain.Category.Value,
             Money = domain.Money.ToString(),
             SortOrder = domain.SortOrder,

--- a/src/Application/MonthlyBillings/MonthlyBillingDTO.cs
+++ b/src/Application/MonthlyBillings/MonthlyBillingDTO.cs
@@ -2,7 +2,7 @@ namespace Application.MonthlyBillings;
 
 public sealed class MonthlyBillingDTO
 {
-    public string Id { get; set; }
+    public Guid Id { get; set; }
     public int Year { get; set; }
     public int Month { get; set; }
     public string State { get; set; }

--- a/src/Application/MonthlyBillings/PlanDTO.cs
+++ b/src/Application/MonthlyBillings/PlanDTO.cs
@@ -2,7 +2,7 @@ namespace Application.MonthlyBillings;
 
 public sealed class PlanDTO
 {
-    public string Id { get; set; }
+    public Guid Id { get; set; }
     public string Category { get; set; }
     public string Money { get; set; }
     public uint SortOrder { get; set; }

--- a/tests/Application.Unit.Tests/MonthlyBillings/AddExpense/AddExpenseCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/AddExpense/AddExpenseCommandHandlerTests.cs
@@ -49,7 +49,7 @@ public sealed class AddExpenseCommandHandlerTests
     {
         // Arrange
         var addExpenseCommand = new AddExpenseCommand(
-            Guid.Parse("753d1889-0502-49f4-be59-25821729f6a9"),
+            Guid.NewGuid(),
             Constants.Plan.Id,
             Constants.Expense.Money,
             Constants.Expense.Currency,

--- a/tests/Application.Unit.Tests/MonthlyBillings/AddExpense/AddExpenseCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/AddExpense/AddExpenseCommandHandlerTests.cs
@@ -102,6 +102,10 @@ public sealed class AddExpenseCommandHandlerTests
         );
 
         // Assert
+        passedMonthlyBilling
+            .Should()
+            .NotBeNull();
+
         passedMonthlyBilling?.Plans
             .First().Expenses
                 .Should()

--- a/tests/Application.Unit.Tests/MonthlyBillings/AddIncome/AddIncomeCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/AddIncome/AddIncomeCommandHandlerTests.cs
@@ -82,7 +82,7 @@ public sealed class AddIncomeCommandHandlerTests
             .Received(1)
             .Save(Arg.Any<MonthlyBilling>());
     }
-    
+
     [Fact]
     public async Task HandleAsync_OnSuccess_PassedArgumentShouldContainNewIncome()
     {
@@ -101,6 +101,10 @@ public sealed class AddIncomeCommandHandlerTests
         );
 
         // Assert
+        passedMonthlyBilling
+            .Should()
+            .NotBeNull();
+
         passedMonthlyBilling?.Incomes
                 .Should()
                 .ContainEquivalentOf(

--- a/tests/Application.Unit.Tests/MonthlyBillings/AddPlan/AddPlanCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/AddPlan/AddPlanCommandHandlerTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection.Metadata;
 using Application.Exceptions;
 using Application.MonthlyBillings.AddPlan;
 using Application.Unit.Tests.MonthlyBillings.TestUtilities;
@@ -6,7 +5,6 @@ using Application.Unit.Tests.TestUtilities;
 using Application.Unit.Tests.TestUtilities.Constants;
 using Domain.MonthlyBillings;
 using Domain.Repositories;
-using NSubstitute.Routing.Handlers;
 
 namespace Application.Unit.Tests.MonthlyBillings.AddPlan;
 

--- a/tests/Application.Unit.Tests/MonthlyBillings/AddPlan/AddPlanCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/AddPlan/AddPlanCommandHandlerTests.cs
@@ -101,6 +101,10 @@ public sealed class AddPlanCommandHandlerTests
         );
 
         // Assert
+        passedArgument
+            .Should()
+            .NotBeNull();
+
         passedArgument?.Plans
             .Should()
             .ContainEquivalentOf(

--- a/tests/Application.Unit.Tests/MonthlyBillings/OpenMonthlyBiling/OpenMonthlyBillingCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/OpenMonthlyBiling/OpenMonthlyBillingCommandHandlerTests.cs
@@ -110,5 +110,17 @@ public sealed class OpenMonthlyBilingCommandHandlerTests
         passedArgument?.State
             .Should()
             .Be(State.Open);
+
+        passedArgument?.Year.Value
+            .Should()
+            .Be(openCommand.Year);
+
+        passedArgument?.Month.Value
+            .Should()
+            .Be(openCommand.Month);
+
+        passedArgument?.Currency.Value
+            .Should()
+            .Be(openCommand.Currency);
     }
 }

--- a/tests/Application.Unit.Tests/MonthlyBillings/OpenMonthlyBiling/OpenMonthlyBillingCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/OpenMonthlyBiling/OpenMonthlyBillingCommandUtilities.cs
@@ -7,8 +7,8 @@ public static class OpenMonthlyBilingCommandUtilities
 {
     public static OpenMonthlyBillingCommand CreateCommand()
         => new (
-            Constants.MonthlyBilling.Year,
-            Constants.MonthlyBilling.Month,
+            Constants.MonthlyBilling.Year + 1,
+            Constants.MonthlyBilling.Month + 1,
             Constants.MonthlyBilling.Currency
         );
 }

--- a/tests/Application.Unit.Tests/MonthlyBillings/RemoveExpense/RemoveExpenseCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/RemoveExpense/RemoveExpenseCommandHandlerTests.cs
@@ -84,7 +84,7 @@ public sealed class RemoveExpenseCommandHandlerTests
     }
 
     [Fact]
-    public async Task HandleAsync_OnSuccess_PassedArgumentShouldDontHaveSelectedExpense()
+    public async Task HandleAsync_OnSuccess_PassedArgumentShouldContainNotActiveExpense()
     {
         // Arrange
         var removeExpenseCommand = RemoveExpenseCommandUtilities.CreateCommand();

--- a/tests/Application.Unit.Tests/MonthlyBillings/RemoveIncome/RemoveIncomeCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/RemoveIncome/RemoveIncomeCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 using Application.Exceptions;
 using Application.MonthlyBillings.RemoveIncome;
 using Application.Unit.Tests.MonthlyBillings.TestUtilities;
+using Application.Unit.Tests.TestUtilities.Constants;
 using Application.Unit.Tests.TestUtilities;
 using Domain.MonthlyBillings;
 using Domain.Repositories;
@@ -15,6 +16,11 @@ public sealed class RemoveIncomeCommandHandlerTests
     public RemoveIncomeCommandHandlerTests()
     {
         _repository = Substitute.For<IMonthlyBillingRepository>();
+
+        _repository
+            .GetById(new(Constants.MonthlyBilling.Id))
+            .Returns(MonthlyBillingUtilities.CreateMonthlyBilling());
+
         _handler = new RemoveIncomeCommandHandler(_repository);
     }
 
@@ -23,16 +29,6 @@ public sealed class RemoveIncomeCommandHandlerTests
     {
         // Arrange
         var command = RemoveIncomeCommandUtilities.CreateCommand();
-        _repository
-            .GetById(new(command.MonthlyBillingId))
-            .Returns(
-                MonthlyBillingUtilities.CreateMonthlyBilling(
-                    incomes: new List<Income>()
-                    {
-                        IncomesUtilities.CreateIncome()
-                    }
-                )
-            );
 
         // Act
         await _handler
@@ -44,52 +40,70 @@ public sealed class RemoveIncomeCommandHandlerTests
         // Assert
         await _repository
             .Received(1)
-            .GetById(new(command.MonthlyBillingId));
+            .GetById(Arg.Is<MonthlyBillingId>(m => m.Value == command.MonthlyBillingId));
     }
 
     [Fact]
-    public async Task HandleAsync_WhenMonthlyBillingDoesntExist_ShouldthrowMonthlyBillingNotFoundException()
+    public async Task HandleAsync_WhenMonthlyBillingDoesntExist_ShouldThrowMonthlyBillingNotFoundException()
     {
         // Arrange
-        var command = RemoveIncomeCommandUtilities.CreateCommand();
+        var removeIncome = new RemoveIncomeCommand(
+            Guid.NewGuid(),
+            Constants.Income.Id
+        );
 
-        var removeIncome = async () => await _handler
+        var removeIncomeAction = async () => await _handler
             .HandleAsync(
-                command,
+                removeIncome,
                 default
             );
 
         // Act & Assert
-        await Assert.ThrowsAsync<MonthlyBillingNotFoundException>(removeIncome);
+        await Assert.ThrowsAsync<MonthlyBillingNotFoundException>(removeIncomeAction);
     }
 
     [Fact]
-    public async Task HandleAsync_WhenPassedProperData_ShouldCallSaveOnRepositoryOnce()
+    public async Task HandleAsync_WhenMonthyBillingFoundAndIncomeRemovedSuccessfully_ShouldCallSaveOnRepositoryOnce()
     {
         // Arrange
-        var command = RemoveIncomeCommandUtilities.CreateCommand();
-        var fakeMonthlyBilling = MonthlyBillingUtilities.CreateMonthlyBilling(
-            incomes: new List<Income>()
-            {
-                IncomesUtilities.CreateIncome()
-            }
-        );
-        _repository
-            .GetById(new(command.MonthlyBillingId))
-            .Returns(fakeMonthlyBilling);
+        var removeIncome = RemoveIncomeCommandUtilities.CreateCommand();
 
         // Act
-        await _handler
-            .HandleAsync(
-                command,
-                default
-            );
+        await _handler.HandleAsync(
+            removeIncome,
+            default
+        );
 
         // Assert
         await _repository
             .Received(1)
-            .Save(Arg.Is<MonthlyBilling>(
-                m => m.Incomes.Any(i => !i.Active)
-            ));
+            .Save(Arg.Any<MonthlyBilling>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_OnSuccess_PassedArgumentShouldContainNotActiveIncome()
+    {
+        // Arrange
+        var removeIncome = RemoveIncomeCommandUtilities.CreateCommand();
+
+        MonthlyBilling passedArgument = null;
+
+        await _repository
+            .Save(Arg.Do<MonthlyBilling>(a => passedArgument = a));
+
+        // Act
+        await _handler.HandleAsync(
+            removeIncome,
+            default
+        );
+
+        // Assert
+        passedArgument
+            .Should()
+            .NotBeNull();
+
+        passedArgument?.Incomes
+            .Should()
+            .ContainSingle(x => x.Active == false);
     }
 }

--- a/tests/Application.Unit.Tests/MonthlyBillings/RemoveIncome/RemoveIncomeCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/RemoveIncome/RemoveIncomeCommandUtilities.cs
@@ -7,7 +7,7 @@ public static class RemoveIncomeCommandUtilities
 {
     public static RemoveIncomeCommand CreateCommand()
         => new(
-            Guid.NewGuid(),
+            Constants.MonthlyBilling.Id,
             Constants.Income.Id
         );
 }

--- a/tests/Application.Unit.Tests/MonthlyBillings/RemovePlan/RemovePlanCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/RemovePlan/RemovePlanCommandUtilities.cs
@@ -7,7 +7,7 @@ public static class RemovePlanCommandUtilities
 {
     public static RemovePlanCommand CreateCommand()
         => new(
-            Guid.NewGuid(),
+            Constants.MonthlyBilling.Id,
             Constants.Plan.Id
         );
 }

--- a/tests/Application.Unit.Tests/MonthlyBillings/ReopenMonthlyBilling/ReopenMonthlyBillingCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/ReopenMonthlyBilling/ReopenMonthlyBillingCommandHandlerTests.cs
@@ -110,6 +110,14 @@ public sealed class ReopenMonthlyBillingCommandHandlerTests
             .Should()
             .NotBeNull();
 
+        passedArgument?.Year.Value
+            .Should()
+            .Be(reopen.Year);
+
+        passedArgument?.Month.Value
+            .Should()
+            .Be(reopen.Month);
+
         passedArgument?.State
             .Should()
             .Be(State.Open);

--- a/tests/Application.Unit.Tests/TestUtilities/Constants/Constants.Expense.cs
+++ b/tests/Application.Unit.Tests/TestUtilities/Constants/Constants.Expense.cs
@@ -6,22 +6,25 @@ public static partial class Constants
 {
     public static class Expense
     {
-        public static readonly Guid Id = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        public static readonly Guid Id = new Guid(0, 0, 0, new byte[8] { 0, 0, 0, 0, 0, 0, 0, 1 });
         public const decimal Money = 928.54m;
         public const string Currency = "PLN";
         public static readonly DateTimeOffset ExpenseDate = new DateTimeOffset(new DateTime(2023, 9, 15), new TimeSpan(1, 0, 0));
         public const string Description = "A short description about the expense";
 
-        public static Money MoneyFromIndex(int index)
+        public static ExpenseId IdFromIndex(byte index)
+            => new(new Guid(0, 0, 0, new byte[8] { 0, 0, 0, 0, 0, 0, 0, (byte)(index + 1) }));
+
+        public static Money MoneyFromIndex(byte index)
             => new(
                 Money * (index + 1),
                 new(Currency)
             );
 
-        public static DateTimeOffset ExpenseDateFromIndex(int index)
+        public static DateTimeOffset ExpenseDateFromIndex(byte index)
             => ExpenseDate.AddDays(index + 1);
 
-        public static string DescriptionFromIndex(int index)
+        public static string DescriptionFromIndex(byte index)
             => $"{Description} {index}";
     }
 }

--- a/tests/Application.Unit.Tests/TestUtilities/Constants/Constants.Income.cs
+++ b/tests/Application.Unit.Tests/TestUtilities/Constants/Constants.Income.cs
@@ -6,22 +6,25 @@ public static partial class Constants
 {
     public static class Income
     {
-        public static readonly Guid Id = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        public static readonly Guid Id = new Guid(0, 0, 0, new byte[8] { 0, 0, 0, 0, 0, 0, 0, 1 });
         public const string Name = "Earn";
         public const decimal Amount = 4321.45m;
         public const string Currency = "PLN";
         public const bool Include = true;
 
-        public static Name NameFromIndex(int index)
+        public static IncomeId IdFromIndex(byte index)
+            => new(new Guid(0, 0, 0, new byte[8] { 0, 0, 0, 0, 0, 0, 0, (byte)(index + 1) }));
+
+        public static Name NameFromIndex(byte index)
             => new($"{Name} {index}");
 
-        public static Money MoneyFromIndex(int index)
+        public static Money MoneyFromIndex(byte index)
             => new(
                 Amount * (index + 1),
                 new(Currency)
             );
 
-        public static bool IncludeFromIndex(int index)
+        public static bool IncludeFromIndex(byte index)
             => index % 2 == 0 ? Include : !Include;
     }
 }

--- a/tests/Application.Unit.Tests/TestUtilities/Constants/Constants.MonthlyBilling.cs
+++ b/tests/Application.Unit.Tests/TestUtilities/Constants/Constants.MonthlyBilling.cs
@@ -6,7 +6,7 @@ public static partial class Constants
 {
     public static class MonthlyBilling
     {
-        public static readonly Guid Id = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        public static readonly Guid Id = new Guid(0, 0, 0, new byte[8] { 0, 0, 0, 0, 0, 0, 0, 1 });
         public const ushort Year = 2023;
         public const byte Month = 7;
         public const string Currency = "PLN";

--- a/tests/Application.Unit.Tests/TestUtilities/Constants/Constants.Plan.cs
+++ b/tests/Application.Unit.Tests/TestUtilities/Constants/Constants.Plan.cs
@@ -6,19 +6,25 @@ public static partial class Constants
 {
     public static class Plan
     {
-        public static readonly Guid Id = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        public static readonly Guid Id = new Guid(0, 0, 0, new byte[8] { 0, 0, 0, 0, 0, 0, 0, 1 });
         public const string Category = "Pay";
         public const decimal MoneyAmount = 2984.12m;
         public const string Currency = "PLN";
         public const uint SortOrder = 1;
 
-        public static Category CategoryFromIndex(int index)
+        public static PlanId IdFromIndex(byte index)
+            => new(new Guid(0, 0, 0, new byte[8] { 0, 0, 0, 0, 0, 0, 0, (byte)(index + 1) }));
+
+        public static Category CategoryFromIndex(byte index)
             => new($"{Category} {index}");
 
-        public static Money MoneyFromIndex(int index)
+        public static Money MoneyFromIndex(byte index)
             => new(
                 MoneyAmount * (index + 1),
-                new (Currency)
+                new(Currency)
             );
+
+        public static uint SortOrderFromIndex(byte index)
+            => SortOrder * (uint)(index + 1);
     }
 }

--- a/tests/Application.Unit.Tests/TestUtilities/ExpenseUtilities.cs
+++ b/tests/Application.Unit.Tests/TestUtilities/ExpenseUtilities.cs
@@ -5,7 +5,7 @@ namespace Application.Unit.Tests.TestUtilities;
 public static class ExpenseUtilities
 {
     public static Expense CreateExpense()
-        => new Expense(
+        => new(
             new(Constants.Constants.Expense.Id),
             new(
                 Constants.Constants.Expense.Money,

--- a/tests/Application.Unit.Tests/TestUtilities/MonthlyBillingUtilities.cs
+++ b/tests/Application.Unit.Tests/TestUtilities/MonthlyBillingUtilities.cs
@@ -5,8 +5,8 @@ namespace Application.Unit.Tests.TestUtilities;
 public static class MonthlyBillingUtilities
 {
     public static MonthlyBilling CreateMonthlyBilling(
-        List<Plan> plans = null,
-        List<Income> incomes = null
+        List<Plan>? plans = null,
+        List<Income>? incomes = null
     )
         => new(
             new(Constants.Constants.MonthlyBilling.Id),
@@ -19,40 +19,40 @@ public static class MonthlyBillingUtilities
         );
 
     public static List<Plan> CreatePlans(
-        List<Expense> expenses = null,
-        int plansCount = 1
+        List<Expense>? expenses = null,
+        byte plansCount = 1
     )
         => Enumerable
             .Range(0, plansCount)
             .Select(r => new Plan(
-                new PlanId(Guid.NewGuid()),
-                Constants.Constants.Plan.CategoryFromIndex(r),
-                Constants.Constants.Plan.MoneyFromIndex(r),
-                (uint)(r + 1),
+                Constants.Constants.Plan.IdFromIndex((byte)r),
+                Constants.Constants.Plan.CategoryFromIndex((byte)r),
+                Constants.Constants.Plan.MoneyFromIndex((byte)r),
+                Constants.Constants.Plan.SortOrderFromIndex((byte)r),
                 expenses ?? CreateExpenses()
             ))
             .ToList();
 
-    public static List<Income> CreateIncomes(int incomesCount = 1)
+    public static List<Income> CreateIncomes(byte incomesCount = 1)
         => Enumerable
             .Range(0, incomesCount)
             .Select(r => new Income(
-                new IncomeId(Guid.NewGuid()),
-                Constants.Constants.Income.NameFromIndex(r),
-                Constants.Constants.Income.MoneyFromIndex(r),
-                Constants.Constants.Income.IncludeFromIndex(r)
+                Constants.Constants.Income.IdFromIndex((byte)r),
+                Constants.Constants.Income.NameFromIndex((byte)r),
+                Constants.Constants.Income.MoneyFromIndex((byte)r),
+                Constants.Constants.Income.IncludeFromIndex((byte)r)
             ))
             .ToList();
 
 
-    public static List<Expense> CreateExpenses(int expensesCount = 2)
+    public static List<Expense> CreateExpenses(byte expensesCount = 2)
         => Enumerable
             .Range(0, expensesCount)
             .Select(r => new Expense(
-                new ExpenseId(Guid.NewGuid()),
-                Constants.Constants.Expense.MoneyFromIndex(r),
-                Constants.Constants.Expense.ExpenseDateFromIndex(r),
-                Constants.Constants.Expense.DescriptionFromIndex(r)
+                Constants.Constants.Expense.IdFromIndex((byte)r),
+                Constants.Constants.Expense.MoneyFromIndex((byte)r),
+                Constants.Constants.Expense.ExpenseDateFromIndex((byte)r),
+                Constants.Constants.Expense.DescriptionFromIndex((byte)r)
             ))
             .ToList();
 }

--- a/tests/Application.Unit.Tests/TestUtilities/PlansUtilities.cs
+++ b/tests/Application.Unit.Tests/TestUtilities/PlansUtilities.cs
@@ -4,7 +4,7 @@ namespace Application.Unit.Tests.TestUtilities;
 
 public static class PlansUtilities
 {
-    public static Plan CreatePlan(List<Expense> expenses = null)
+    public static Plan CreatePlan(List<Expense>? expenses = null)
         => new(
             new(Constants.Constants.Plan.Id),
             new(Constants.Constants.Plan.Category),


### PR DESCRIPTION
### What?

I'm refactoring unit tests for `Application` layer because they were not really readable and cohesive. \
After changes in unit tests I test branching (like if monthly billing is not found, I test if the excpetion was thrown), methods called (`Save()` or `GetById()` on repository interface) and passed arguments to the repository methods from the command handler.

### Why?

Unit tests for command and query handlers should test only the things that handlers do. For e.g. if in a handler there is an `if` statement, unit test should check that branching only. \
These tests shouldn't test what is happening inside methods called in handlers.

### How?

In most scenarios I create tests like:
- verify if there was a call to `GetById()` or `Get()` on repository only once,
- verify if exception was thrown - for not found monthly billing,
- verify if the `Save()` method was called (with any argument),
- verify if argument passed to the `Save()` method has the data that was modified inside handler (by domain object).

#### Additional informations

- Removed acitivity flag from `IncomeDTO` class, for easier assertion in `Get` query.

Related to #57 and #62 