### PR TITLE
#69 Feature - `User` linked to `MonthlyBilling`

### DIFF
--- a/requests/Expenses/AddExpense.http
+++ b/requests/Expenses/AddExpense.http
@@ -1,14 +1,15 @@
 @host = https://localhost:7188
 
-@monthlyBillingId = 820db3c1-70b7-484a-b4f4-4304bb62d32a
-@planId = 102c9a20-6dc5-408a-984f-60df68e897df
+@monthlyBillingId = 5ef03521-3296-4866-bbaf-369f6c117fee
+@planId = 176ab79c-22f8-4868-88ac-c567d1c26208
 
 POST {{host}}/api/monthlyBillings/{{monthlyBillingId}}/plans/{{planId}}/expenses
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1N2E5YjNlYi0xNzk2LTRlMGQtYTZiNC1mYzEwYmQzZjkzYjIiLCJ1bmlxdWVfbmFtZSI6IjU3YTliM2ViLTE3OTYtNGUwZC1hNmI0LWZjMTBiZDNmOTNiMiIsIm5iZiI6MTY5NzE0NDExMSwiZXhwIjoxNjk3MTQ1MzExLCJpc3MiOiJzbXVnZXQtaXNzdWVyIiwiYXVkIjoic211Z2V0LWF1ZGllbmNlIn0.GkZ_Y73COw8Vt9P51JvLquLBUxdsEQCm_bpefZ2ziDo
 Content-Type: application/json
 
 {
-    "money": 32.78,
+    "money": 452.62,
     "currency": "PLN",
-    "expenseDate": "2023-08-15T17:33:17+00:00",
-    "description": "Auchan"
+    "expenseDate": "2023-10-23T14:59:17+00:00",
+    "description": "Akumulator do samochodu"
 }

--- a/requests/Expenses/RemoveExpense.http
+++ b/requests/Expenses/RemoveExpense.http
@@ -1,8 +1,9 @@
 @host = https://localhost:7188
 
-@monthlyBillingId = 2330a403-64e8-4325-b38c-cb229e2ba9b2
-@planId = a3d2fc36-0d6f-4424-9b4d-af3979b3fc4b
-@expenseId = 561b1ef2-312a-4adf-935d-db99a4fc183d
+@monthlyBillingId = 5ef03521-3296-4866-bbaf-369f6c117fee
+@planId = 176ab79c-22f8-4868-88ac-c567d1c26208
+@expenseId = dd18198f-31f0-4148-93a5-986fc83c2bb9
 
 DELETE {{host}}/api/monthlyBillings/{{monthlyBillingId}}/plans/{{planId}}/expenses/{{expenseId}}
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1N2E5YjNlYi0xNzk2LTRlMGQtYTZiNC1mYzEwYmQzZjkzYjIiLCJ1bmlxdWVfbmFtZSI6IjU3YTliM2ViLTE3OTYtNGUwZC1hNmI0LWZjMTBiZDNmOTNiMiIsIm5iZiI6MTY5NzE0NDExMSwiZXhwIjoxNjk3MTQ1MzExLCJpc3MiOiJzbXVnZXQtaXNzdWVyIiwiYXVkIjoic211Z2V0LWF1ZGllbmNlIn0.GkZ_Y73COw8Vt9P51JvLquLBUxdsEQCm_bpefZ2ziDo
 Accept: application/json

--- a/requests/Expenses/UpdateExpense.http
+++ b/requests/Expenses/UpdateExpense.http
@@ -1,15 +1,16 @@
 @host = https://localhost:7188
 
-@monthlyBillingId = ea157cb3-b923-47fc-b258-cd2fbd5f4c76
-@planId = 7315f446-2139-4ed4-a0cc-c9c0befc3915
-@expenseId = d1d31227-6594-47cb-8eb2-2dfe29a64a1d
+@monthlyBillingId = 5ef03521-3296-4866-bbaf-369f6c117fee
+@planId = 176ab79c-22f8-4868-88ac-c567d1c26208
+@expenseId = f1e8ffc1-ac67-464f-8736-fa1aa85986ac
 
 PUT {{host}}/api/monthlyBillings/{{monthlyBillingId}}/plans/{{planId}}/expenses/{{expenseId}}
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1N2E5YjNlYi0xNzk2LTRlMGQtYTZiNC1mYzEwYmQzZjkzYjIiLCJ1bmlxdWVfbmFtZSI6IjU3YTliM2ViLTE3OTYtNGUwZC1hNmI0LWZjMTBiZDNmOTNiMiIsIm5iZiI6MTY5NzE0NDExMSwiZXhwIjoxNjk3MTQ1MzExLCJpc3MiOiJzbXVnZXQtaXNzdWVyIiwiYXVkIjoic211Z2V0LWF1ZGllbmNlIn0.GkZ_Y73COw8Vt9P51JvLquLBUxdsEQCm_bpefZ2ziDo
 Content-Type: application/json
 
 {
-    "moneyAmount": 39.23,
+    "moneyAmount": 85.45,
     "currency": "PLN",
-    "expenseDate": "2023-01-02T23:55:55+00:00",
-    "description": "Zaktualizownay opis 1"
+    "expenseDate": "2023-10-15T16:54:11+00:00",
+    "description": "Lidl"
 }

--- a/requests/Incomes/AddIncome.http
+++ b/requests/Incomes/AddIncome.http
@@ -1,13 +1,14 @@
 @host = https://localhost:7188
 
-@id = 820db3c1-70b7-484a-b4f4-4304bb62d32a
+@id = 5ef03521-3296-4866-bbaf-369f6c117fee
 
 POST {{host}}/api/monthlyBillings/{{id}}/incomes
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1N2E5YjNlYi0xNzk2LTRlMGQtYTZiNC1mYzEwYmQzZjkzYjIiLCJ1bmlxdWVfbmFtZSI6IjU3YTliM2ViLTE3OTYtNGUwZC1hNmI0LWZjMTBiZDNmOTNiMiIsIm5iZiI6MTY5NzE0MjQ0NiwiZXhwIjoxNjk3MTQzNjQ2LCJpc3MiOiJzbXVnZXQtaXNzdWVyIiwiYXVkIjoic211Z2V0LWF1ZGllbmNlIn0.KRKiFKHdfnHARjn7QbLZelx4lRukhCXXpYVTHd0TZhQ
 Content-Type: application/json
 
 {
-    "name": "Wypłata",
-    "moneyAmount": 7778,
+    "name": "Zwrot z zakupów",
+    "moneyAmount": 254,
     "currency": "PLN",
-    "includeInBilling": true
+    "includeInBilling": false
 }

--- a/requests/Incomes/RemoveIncome.http
+++ b/requests/Incomes/RemoveIncome.http
@@ -1,7 +1,8 @@
 @host = https://localhost:7188
 
-@monthlyBillingId = 9c237933-b0cd-4d84-966e-92549efe1f3e
-@incomeId = 1ec96bf6-8be0-48c6-90ea-e1520576f9fa
+@monthlyBillingId = 5ef03521-3296-4866-bbaf-369f6c117fee
+@incomeId = 623dceb6-af02-4307-a856-686893019b0f
 
 DELETE {{host}}/api/monthlyBillings/{{monthlyBillingId}}/incomes/{{incomeId}}
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1N2E5YjNlYi0xNzk2LTRlMGQtYTZiNC1mYzEwYmQzZjkzYjIiLCJ1bmlxdWVfbmFtZSI6IjU3YTliM2ViLTE3OTYtNGUwZC1hNmI0LWZjMTBiZDNmOTNiMiIsIm5iZiI6MTY5NzE0MjQ0NiwiZXhwIjoxNjk3MTQzNjQ2LCJpc3MiOiJzbXVnZXQtaXNzdWVyIiwiYXVkIjoic211Z2V0LWF1ZGllbmNlIn0.KRKiFKHdfnHARjn7QbLZelx4lRukhCXXpYVTHd0TZhQ
 Accept: application/json

--- a/requests/Incomes/UpdateIncome.http
+++ b/requests/Incomes/UpdateIncome.http
@@ -1,14 +1,15 @@
 @host = https://localhost:7188
 
-@monthlyBillingId = f26ff0b4-a1ad-4517-b78e-2ed1c34c808f
-@incomeId = 03fcf4a6-cad4-4f18-8b40-19a4760443d1
+@monthlyBillingId = 5ef03521-3296-4866-bbaf-369f6c117fee
+@incomeId = 623dceb6-af02-4307-a856-686893019b0f
 
 PUT {{host}}/api/monthlyBillings/{{monthlyBillingId}}/incomes/{{incomeId}}
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1N2E5YjNlYi0xNzk2LTRlMGQtYTZiNC1mYzEwYmQzZjkzYjIiLCJ1bmlxdWVfbmFtZSI6IjU3YTliM2ViLTE3OTYtNGUwZC1hNmI0LWZjMTBiZDNmOTNiMiIsIm5iZiI6MTY5NzE0MjQ0NiwiZXhwIjoxNjk3MTQzNjQ2LCJpc3MiOiJzbXVnZXQtaXNzdWVyIiwiYXVkIjoic211Z2V0LWF1ZGllbmNlIn0.KRKiFKHdfnHARjn7QbLZelx4lRukhCXXpYVTHd0TZhQ
 Content-Type: application/json
 
 {
-    "name": "Wypłata",
-    "moneyAmount": 2525.12,
-    "currency": "EUR",
-    "include": false
+    "name": "Premia",
+    "moneyAmount": 852,
+    "currency": "PLN",
+    "include": true
 }

--- a/requests/MonthlyBillings/Close.http
+++ b/requests/MonthlyBillings/Close.http
@@ -3,3 +3,4 @@
 @month = 10
 
 PUT {{host}}/api/monthlyBillings/{{year}}/{{month}}/close
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1N2E5YjNlYi0xNzk2LTRlMGQtYTZiNC1mYzEwYmQzZjkzYjIiLCJ1bmlxdWVfbmFtZSI6IjU3YTliM2ViLTE3OTYtNGUwZC1hNmI0LWZjMTBiZDNmOTNiMiIsIm5iZiI6MTY5NzE0MjQ0NiwiZXhwIjoxNjk3MTQzNjQ2LCJpc3MiOiJzbXVnZXQtaXNzdWVyIiwiYXVkIjoic211Z2V0LWF1ZGllbmNlIn0.KRKiFKHdfnHARjn7QbLZelx4lRukhCXXpYVTHd0TZhQ

--- a/requests/MonthlyBillings/Get.http
+++ b/requests/MonthlyBillings/Get.http
@@ -1,7 +1,8 @@
 @host = https://localhost:7188
 
-@year = 2020
-@month = 4
+@year = 2023
+@month = 10
 
 GET {{host}}/api/monthlyBillings/{{year}}/{{month}}
 Accept: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1N2E5YjNlYi0xNzk2LTRlMGQtYTZiNC1mYzEwYmQzZjkzYjIiLCJ1bmlxdWVfbmFtZSI6IjU3YTliM2ViLTE3OTYtNGUwZC1hNmI0LWZjMTBiZDNmOTNiMiIsIm5iZiI6MTY5NzE0NDExMSwiZXhwIjoxNjk3MTQ1MzExLCJpc3MiOiJzbXVnZXQtaXNzdWVyIiwiYXVkIjoic211Z2V0LWF1ZGllbmNlIn0.GkZ_Y73COw8Vt9P51JvLquLBUxdsEQCm_bpefZ2ziDo

--- a/requests/MonthlyBillings/Open.http
+++ b/requests/MonthlyBillings/Open.http
@@ -1,10 +1,11 @@
 @host = https://localhost:7188
 
 POST {{host}}/api/monthlyBillings
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1N2E5YjNlYi0xNzk2LTRlMGQtYTZiNC1mYzEwYmQzZjkzYjIiLCJ1bmlxdWVfbmFtZSI6IjU3YTliM2ViLTE3OTYtNGUwZC1hNmI0LWZjMTBiZDNmOTNiMiIsIm5iZiI6MTY5NzE0MjQ0NiwiZXhwIjoxNjk3MTQzNjQ2LCJpc3MiOiJzbXVnZXQtaXNzdWVyIiwiYXVkIjoic211Z2V0LWF1ZGllbmNlIn0.KRKiFKHdfnHARjn7QbLZelx4lRukhCXXpYVTHd0TZhQ
 Content-Type: application/json
 
 {
     "Year": 2023,
-    "Month": 12,
+    "Month": 10,
     "Currency": "PLN"
 }

--- a/requests/MonthlyBillings/Reopen.http
+++ b/requests/MonthlyBillings/Reopen.http
@@ -1,5 +1,6 @@
 @host = https://localhost:7188
-@year = 2022
-@month = 9
+@year = 2023
+@month = 10
 
 PUT {{host}}/api/monthlyBillings/{{year}}/{{month}}/reopen
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1N2E5YjNlYi0xNzk2LTRlMGQtYTZiNC1mYzEwYmQzZjkzYjIiLCJ1bmlxdWVfbmFtZSI6IjU3YTliM2ViLTE3OTYtNGUwZC1hNmI0LWZjMTBiZDNmOTNiMiIsIm5iZiI6MTY5NzE0MjQ0NiwiZXhwIjoxNjk3MTQzNjQ2LCJpc3MiOiJzbXVnZXQtaXNzdWVyIiwiYXVkIjoic211Z2V0LWF1ZGllbmNlIn0.KRKiFKHdfnHARjn7QbLZelx4lRukhCXXpYVTHd0TZhQ

--- a/requests/Plans/AddPlan.http
+++ b/requests/Plans/AddPlan.http
@@ -1,13 +1,14 @@
 @host = https://localhost:7188
 
-@id = 820db3c1-70b7-484a-b4f4-4304bb62d32a
+@id = 5ef03521-3296-4866-bbaf-369f6c117fee
 
 POST {{host}}/api/monthlyBillings/{{id}}/plans
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1N2E5YjNlYi0xNzk2LTRlMGQtYTZiNC1mYzEwYmQzZjkzYjIiLCJ1bmlxdWVfbmFtZSI6IjU3YTliM2ViLTE3OTYtNGUwZC1hNmI0LWZjMTBiZDNmOTNiMiIsIm5iZiI6MTY5NzE0MjQ0NiwiZXhwIjoxNjk3MTQzNjQ2LCJpc3MiOiJzbXVnZXQtaXNzdWVyIiwiYXVkIjoic211Z2V0LWF1ZGllbmNlIn0.KRKiFKHdfnHARjn7QbLZelx4lRukhCXXpYVTHd0TZhQ
 Content-Type: application/json
 
 {
-    "category": "Test 2",
-    "money": 123.45,
+    "category": "Leki",
+    "money": 250,
     "currency": "PLN",
-    "sortOrder": 5
+    "sortOrder": 3
 }

--- a/requests/Plans/RemovePlan.http
+++ b/requests/Plans/RemovePlan.http
@@ -1,7 +1,8 @@
 @host = https://localhost:7188
 
-@monthlyBillingId = f26ff0b4-a1ad-4517-b78e-2ed1c34c808f
-@planId = cc1872a8-0fe5-46e3-91bd-5c1eebfdb97f
+@monthlyBillingId = 5ef03521-3296-4866-bbaf-369f6c117fee
+@planId = d7f53bea-f76f-43a7-98da-4d95a9361050
 
 DELETE {{host}}/api/monthlyBillings/{{monthlyBillingId}}/plans/{{planId}}
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1N2E5YjNlYi0xNzk2LTRlMGQtYTZiNC1mYzEwYmQzZjkzYjIiLCJ1bmlxdWVfbmFtZSI6IjU3YTliM2ViLTE3OTYtNGUwZC1hNmI0LWZjMTBiZDNmOTNiMiIsIm5iZiI6MTY5NzE0NDExMSwiZXhwIjoxNjk3MTQ1MzExLCJpc3MiOiJzbXVnZXQtaXNzdWVyIiwiYXVkIjoic211Z2V0LWF1ZGllbmNlIn0.GkZ_Y73COw8Vt9P51JvLquLBUxdsEQCm_bpefZ2ziDo
 Accept: application/json

--- a/requests/Plans/UpdatePlan.http
+++ b/requests/Plans/UpdatePlan.http
@@ -1,14 +1,15 @@
 @host = https://localhost:7188
 
-@monthlyBillingId = 2330a403-64e8-4325-b38c-cb229e2ba9b2
-@planId = a3d2fc36-0d6f-4424-9b4d-af3979b3fc4b
+@monthlyBillingId = 5ef03521-3296-4866-bbaf-369f6c117fee
+@planId = 33473ed1-f734-41c0-a79b-480445332c55
 
 PUT {{host}}/api/monthlyBillings/{{monthlyBillingId}}/plans/{{planId}}
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1N2E5YjNlYi0xNzk2LTRlMGQtYTZiNC1mYzEwYmQzZjkzYjIiLCJ1bmlxdWVfbmFtZSI6IjU3YTliM2ViLTE3OTYtNGUwZC1hNmI0LWZjMTBiZDNmOTNiMiIsIm5iZiI6MTY5NzE0MjQ0NiwiZXhwIjoxNjk3MTQzNjQ2LCJpc3MiOiJzbXVnZXQtaXNzdWVyIiwiYXVkIjoic211Z2V0LWF1ZGllbmNlIn0.KRKiFKHdfnHARjn7QbLZelx4lRukhCXXpYVTHd0TZhQ
 Content-Type: application/json
 
 {
-    "category": "Żywność",
-    "moneyAmount": 321.54,
+    "category": "Czynsz",
+    "moneyAmount": 1321.54,
     "currency": "PLN",
-    "sortOrder": 12
+    "sortOrder": 0
 }

--- a/requests/Users/Login.http
+++ b/requests/Users/Login.http
@@ -4,6 +4,6 @@ POST {{host}}/api/users/login
 Content-Type: application/json
 
 {
-    "Email": "patrykpatryk@patryk.pl",
-    "Password": "1qA)rfvg"
+    "Email": "test2@user.pl",
+    "Password": "Pas$w0rd1"
 }

--- a/requests/Users/Register.http
+++ b/requests/Users/Register.http
@@ -4,7 +4,7 @@ POST {{host}}/api/users/register
 Content-Type: application/json
 
 {
-    "Email": "patrykpatryk@patryk.pl",
-    "FirstName": "Patryk",
-    "Password": "1qA)rfvg"
+    "Email": "test2@user.pl",
+    "FirstName": "Test2",
+    "Password": "Pas$w0rd1"
 }

--- a/src/Application/MonthlyBillings/AddExpense/AddExpenseCommand.cs
+++ b/src/Application/MonthlyBillings/AddExpense/AddExpenseCommand.cs
@@ -8,5 +8,6 @@ public sealed record AddExpenseCommand(
     decimal Money,
     string Currency,
     DateTimeOffset ExpenseDate,
-    string Description
+    string Description,
+    Guid UserId
 ) : ICommand;

--- a/src/Application/MonthlyBillings/AddIncome/AddIncomeCommand.cs
+++ b/src/Application/MonthlyBillings/AddIncome/AddIncomeCommand.cs
@@ -7,5 +7,6 @@ public sealed record AddIncomeCommand(
     string Name,
     decimal Amount,
     string Currency,
-    bool Include
+    bool Include,
+    Guid UserId
 ) : ICommand;

--- a/src/Application/MonthlyBillings/AddIncome/AddIncomeCommandHandler.cs
+++ b/src/Application/MonthlyBillings/AddIncome/AddIncomeCommandHandler.cs
@@ -9,34 +9,34 @@ public sealed class AddIncomeCommandHandler : ICommandHandler<AddIncomeCommand>
 {
     private readonly IMonthlyBillingsRepository _repository;
 
-    public AddIncomeCommandHandler(IMonthlyBillingsRepository repository)
+    public AddIncomeCommandHandler(
+        IMonthlyBillingsRepository repository
+    )
     {
-        _repository = repository;
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
     }
 
-    public async Task HandleAsync(AddIncomeCommand command, CancellationToken cancellationToken = default)
+    public async Task HandleAsync(
+        AddIncomeCommand command,
+        CancellationToken cancellationToken = default
+    )
     {
-        var monthlyBilling = await _repository.GetById(
-            new MonthlyBillingId(command.MonthlyBillingId)
-        );
-
-        if (monthlyBilling is null)
-        {
-            throw new MonthlyBillingNotFoundException();
-        }
+        var entity = await _repository.GetById(
+            new(command.MonthlyBillingId),
+            new(command.UserId)
+        ) ?? throw new MonthlyBillingNotFoundException();
 
         var income = new Income(
-            new IncomeId(Guid.NewGuid()),
-            new Name(command.Name),
-            new Money(
+            new(Guid.NewGuid()),
+            new(command.Name),
+            new(
                 command.Amount,
-                new Currency(command.Currency)
+                new(command.Currency)
             ),
             command.Include
         );
 
-        monthlyBilling.AddIncome(income);
-
-        await _repository.Save(monthlyBilling);
+        entity.AddIncome(income);
+        await _repository.Save(entity);
     }
 }

--- a/src/Application/MonthlyBillings/AddPlan/AddPlanCommand.cs
+++ b/src/Application/MonthlyBillings/AddPlan/AddPlanCommand.cs
@@ -7,5 +7,6 @@ public sealed record AddPlanCommand(
     string Category,
     decimal MoneyAmount,
     string Currency,
-    uint SortOrder
+    uint SortOrder,
+    Guid UserId
 ) : ICommand;

--- a/src/Application/MonthlyBillings/CloseMonthlyBilling/CloseMonthlyBillingCommand.cs
+++ b/src/Application/MonthlyBillings/CloseMonthlyBilling/CloseMonthlyBillingCommand.cs
@@ -4,5 +4,6 @@ namespace Application.MonthlyBillings.CloseMonthlyBilling;
 
 public sealed record CloseMonthlyBillingCommand(
     int Year,
-    int Month
+    int Month,
+    Guid UserId
 ) : ICommand;

--- a/src/Application/MonthlyBillings/GetByYearAndMonth/GetMonthlyBillingByYearAndMonthQuery.cs
+++ b/src/Application/MonthlyBillings/GetByYearAndMonth/GetMonthlyBillingByYearAndMonthQuery.cs
@@ -5,5 +5,6 @@ namespace Application.MonthlyBillings.GetByYearAndMonth;
 
 public sealed record GetMonthlyBillingByYearAndMonthQuery(
     ushort Year,
-    byte Month
+    byte Month,
+    Guid UserId
 ) : IQuery<MonthlyBillingDTO>;

--- a/src/Application/MonthlyBillings/GetByYearAndMonth/GetMonthlyBillingByYearAndMonthQueryHandler.cs
+++ b/src/Application/MonthlyBillings/GetByYearAndMonth/GetMonthlyBillingByYearAndMonthQueryHandler.cs
@@ -1,19 +1,21 @@
 using Application.Abstractions.CQRS;
 using Application.Exceptions;
 using Application.MonthlyBillings.Mappings;
-using Domain.MonthlyBillings;
 using Domain.Repositories;
 
 namespace Application.MonthlyBillings.GetByYearAndMonth;
 
 // TODO: Read model (CQRS) - implement faster data reading
-public sealed class GetMonthlyBillingByYearAndMonthQueryHandler : IQueryHandler<GetMonthlyBillingByYearAndMonthQuery, MonthlyBillingDTO>
+public sealed class GetMonthlyBillingByYearAndMonthQueryHandler
+    : IQueryHandler<GetMonthlyBillingByYearAndMonthQuery, MonthlyBillingDTO>
 {
     private readonly IMonthlyBillingsRepository _repository;
 
-    public GetMonthlyBillingByYearAndMonthQueryHandler(IMonthlyBillingsRepository repository)
+    public GetMonthlyBillingByYearAndMonthQueryHandler(
+        IMonthlyBillingsRepository repository
+    )
     {
-        _repository = repository;
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
     }
 
     public async Task<MonthlyBillingDTO> HandleAsync(
@@ -21,12 +23,15 @@ public sealed class GetMonthlyBillingByYearAndMonthQueryHandler : IQueryHandler<
         CancellationToken token = default
     )
     {
-        var monthlyBilling = await _repository.Get(
-            new Year(query.Year),
-            new Month(query.Month)
-        ) ?? throw new MonthlyBillingNotFoundException(query.Year, query.Month);
+        var entity = await _repository.Get(
+            new(query.Year),
+            new(query.Month),
+            new(query.UserId)
+        ) ?? throw new MonthlyBillingNotFoundException(
+                query.Year,
+                query.Month
+            );
 
-        return monthlyBilling
-            .ToDTO();
+        return entity.ToDTO();
     }
 }

--- a/src/Application/MonthlyBillings/OpenMonthlyBilling/OpenMonthlyBillingCommand.cs
+++ b/src/Application/MonthlyBillings/OpenMonthlyBilling/OpenMonthlyBillingCommand.cs
@@ -5,5 +5,6 @@ namespace Application.MonthlyBillings.OpenMonthlyBilling;
 public sealed record OpenMonthlyBillingCommand(
     ushort Year,
     byte Month,
-    string Currency
+    string Currency,
+    Guid UserId
 ) : ICommand;

--- a/src/Application/MonthlyBillings/RemoveExpense/RemoveExpenseCommand.cs
+++ b/src/Application/MonthlyBillings/RemoveExpense/RemoveExpenseCommand.cs
@@ -5,5 +5,6 @@ namespace Application.MonthlyBillings.RemoveExpense;
 public sealed record RemoveExpenseCommand(
     Guid MonthlyBillingId,
     Guid PlanId,
-    Guid ExpenseId
+    Guid ExpenseId,
+    Guid UserId
 ) : ICommand;

--- a/src/Application/MonthlyBillings/RemoveExpense/RemoveExpenseCommandHandler.cs
+++ b/src/Application/MonthlyBillings/RemoveExpense/RemoveExpenseCommandHandler.cs
@@ -1,6 +1,5 @@
 using Application.Abstractions.CQRS;
 using Application.Exceptions;
-using Domain.MonthlyBillings;
 using Domain.Repositories;
 
 namespace Application.MonthlyBillings.RemoveExpense;
@@ -9,22 +8,27 @@ public sealed class RemoveExpenseCommandHandler : ICommandHandler<RemoveExpenseC
 {
     private readonly IMonthlyBillingsRepository _repository;
 
-    public RemoveExpenseCommandHandler(IMonthlyBillingsRepository repository)
+    public RemoveExpenseCommandHandler(
+        IMonthlyBillingsRepository repository
+    )
     {
-        _repository = repository;
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
     }
 
-    public async Task HandleAsync(RemoveExpenseCommand command, CancellationToken cancellationToken = default)
+    public async Task HandleAsync(
+        RemoveExpenseCommand command,
+        CancellationToken cancellationToken = default
+    )
     {
-        MonthlyBillingId monthlyBillingId = new(command.MonthlyBillingId);
-        var entity = await _repository.GetById(monthlyBillingId)
-            ?? throw new MonthlyBillingNotFoundException();
+        var entity = await _repository.GetById(
+            new(command.MonthlyBillingId),
+            new(command.UserId)
+        ) ?? throw new MonthlyBillingNotFoundException();
 
         entity.RemoveExpense(
             new(command.PlanId),
             new(command.ExpenseId)
         );
-
         await _repository.Save(entity);
     }
 }

--- a/src/Application/MonthlyBillings/RemoveIncome/RemoveIncomeCommand.cs
+++ b/src/Application/MonthlyBillings/RemoveIncome/RemoveIncomeCommand.cs
@@ -4,5 +4,6 @@ namespace Application.MonthlyBillings.RemoveIncome;
 
 public sealed record RemoveIncomeCommand(
     Guid MonthlyBillingId,
-    Guid IncomeId
+    Guid IncomeId,
+    Guid UserId
 ) : ICommand;

--- a/src/Application/MonthlyBillings/RemoveIncome/RemoveIncomeCommandHandler.cs
+++ b/src/Application/MonthlyBillings/RemoveIncome/RemoveIncomeCommandHandler.cs
@@ -1,6 +1,5 @@
 using Application.Abstractions.CQRS;
 using Application.Exceptions;
-using Domain.MonthlyBillings;
 using Domain.Repositories;
 
 namespace Application.MonthlyBillings.RemoveIncome;
@@ -9,9 +8,11 @@ public sealed class RemoveIncomeCommandHandler : ICommandHandler<RemoveIncomeCom
 {
     private readonly IMonthlyBillingsRepository _repository;
 
-    public RemoveIncomeCommandHandler(IMonthlyBillingsRepository repository)
+    public RemoveIncomeCommandHandler(
+        IMonthlyBillingsRepository repository
+    )
     {
-        _repository = repository;
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
     }
 
     public async Task HandleAsync(
@@ -19,13 +20,12 @@ public sealed class RemoveIncomeCommandHandler : ICommandHandler<RemoveIncomeCom
         CancellationToken cancellationToken = default
     )
     {
-        MonthlyBillingId monthlyBillingId = new(command.MonthlyBillingId);
-        var entity = await _repository.GetById(monthlyBillingId)
-            ?? throw new MonthlyBillingNotFoundException();
+        var entity = await _repository.GetById(
+            new(command.MonthlyBillingId),
+            new(command.UserId)
+        ) ?? throw new MonthlyBillingNotFoundException();
 
-        IncomeId incomeId = new(command.IncomeId);
-        entity.RemoveIncome(incomeId);
-
+        entity.RemoveIncome(new(command.IncomeId));
         await _repository.Save(entity);
     }
 }

--- a/src/Application/MonthlyBillings/RemovePlan/RemovePlanCommand.cs
+++ b/src/Application/MonthlyBillings/RemovePlan/RemovePlanCommand.cs
@@ -4,5 +4,6 @@ namespace Application.MonthlyBillings.RemovePlan;
 
 public sealed record RemovePlanCommand(
     Guid MonthlyBillingId,
-    Guid PlanId
+    Guid PlanId,
+    Guid UserId
 ) : ICommand;

--- a/src/Application/MonthlyBillings/RemovePlan/RemovePlanCommandHandler.cs
+++ b/src/Application/MonthlyBillings/RemovePlan/RemovePlanCommandHandler.cs
@@ -1,6 +1,5 @@
 using Application.Abstractions.CQRS;
 using Application.Exceptions;
-using Domain.MonthlyBillings;
 using Domain.Repositories;
 
 namespace Application.MonthlyBillings.RemovePlan;
@@ -9,9 +8,11 @@ public sealed class RemovePlanCommandHandler : ICommandHandler<RemovePlanCommand
 {
     private readonly IMonthlyBillingsRepository _repository;
 
-    public RemovePlanCommandHandler(IMonthlyBillingsRepository repository)
+    public RemovePlanCommandHandler(
+        IMonthlyBillingsRepository repository
+    )
     {
-        _repository = repository;
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
     }
 
     public async Task HandleAsync(
@@ -19,13 +20,12 @@ public sealed class RemovePlanCommandHandler : ICommandHandler<RemovePlanCommand
         CancellationToken cancellationToken = default
     )
     {
-        MonthlyBillingId monthlyBillingId = new(command.MonthlyBillingId);
-        var entity = await _repository.GetById(monthlyBillingId)
-            ?? throw new MonthlyBillingNotFoundException();
+        var entity = await _repository.GetById(
+            new(command.MonthlyBillingId),
+            new(command.UserId)
+        ) ?? throw new MonthlyBillingNotFoundException();
 
-        PlanId PlanId = new(command.PlanId);
-        entity.RemovePlan(PlanId);
-
+        entity.RemovePlan(new(command.PlanId));
         await _repository.Save(entity);
     }
 }

--- a/src/Application/MonthlyBillings/ReopenMonthlyBilling/ReopenMonthlyBillingCommand.cs
+++ b/src/Application/MonthlyBillings/ReopenMonthlyBilling/ReopenMonthlyBillingCommand.cs
@@ -4,5 +4,6 @@ namespace Application.MonthlyBillings.ReopenMonthlyBilling;
 
 public sealed record ReopenMonthlyBillingCommand(
     ushort Year,
-    byte Month
+    byte Month,
+    Guid UserId
 ) : ICommand;

--- a/src/Application/MonthlyBillings/UpdateExpense/UpdateExpenseCommand.cs
+++ b/src/Application/MonthlyBillings/UpdateExpense/UpdateExpenseCommand.cs
@@ -9,5 +9,6 @@ public sealed record UpdateExpenseCommand(
     decimal MoneyAmount,
     string Currency,
     DateTimeOffset ExpenseDate,
-    string Description
+    string Description,
+    Guid UserId
 ) : ICommand;

--- a/src/Application/MonthlyBillings/UpdateExpense/UpdateExpenseCommandHandler.cs
+++ b/src/Application/MonthlyBillings/UpdateExpense/UpdateExpenseCommandHandler.cs
@@ -1,6 +1,5 @@
 using Application.Abstractions.CQRS;
 using Application.Exceptions;
-using Domain.MonthlyBillings;
 using Domain.Repositories;
 
 namespace Application.MonthlyBillings.UpdateExpense;
@@ -13,27 +12,29 @@ public sealed class UpdateExpenseCommandHandler : ICommandHandler<UpdateExpenseC
         IMonthlyBillingsRepository repository
     )
     {
-        _repository = repository;
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
     }
 
-    public async Task HandleAsync(UpdateExpenseCommand command, CancellationToken cancellationToken = default)
+    public async Task HandleAsync(
+        UpdateExpenseCommand command,
+        CancellationToken cancellationToken = default
+    )
     {
-        var monthlyBillingId = new MonthlyBillingId(command.MonthlyBillingId);
-        var entity = await _repository.GetById(monthlyBillingId);
-
-        if (entity is null)
-        {
-            throw new MonthlyBillingNotFoundException();
-        }
+        var entity = await _repository.GetById(
+            new(command.MonthlyBillingId),
+            new(command.UserId)
+        ) ?? throw new MonthlyBillingNotFoundException();
 
         entity.UpdateExpense(
             new(command.PlanId),
             new(command.ExpenseId),
-            new(command.MoneyAmount, new(command.Currency)),
+            new(
+                command.MoneyAmount,
+                new(command.Currency)
+            ),
             command.ExpenseDate,
             command.Description
         );
-
         await _repository.Save(entity);
     }
 }

--- a/src/Application/MonthlyBillings/UpdateIncome/UpdateIncomeCommand.cs
+++ b/src/Application/MonthlyBillings/UpdateIncome/UpdateIncomeCommand.cs
@@ -8,5 +8,6 @@ public sealed record UpdateIncomeCommand(
     string Name,
     decimal MoneyAmount,
     string Currency,
-    bool Include
+    bool Include,
+    Guid UserId
 ) : ICommand;

--- a/src/Application/MonthlyBillings/UpdatePlan/UpdatePlanCommand.cs
+++ b/src/Application/MonthlyBillings/UpdatePlan/UpdatePlanCommand.cs
@@ -8,5 +8,6 @@ public sealed record UpdatePlanCommand(
     string Category,
     decimal MoneyAmount,
     string Currency,
-    uint SortOrder
+    uint SortOrder,
+    Guid UserId
 ) : ICommand;

--- a/src/Application/MonthlyBillings/UpdatePlan/UpdatePlanCommandHandler.cs
+++ b/src/Application/MonthlyBillings/UpdatePlan/UpdatePlanCommandHandler.cs
@@ -1,6 +1,5 @@
 using Application.Abstractions.CQRS;
 using Application.Exceptions;
-using Domain.MonthlyBillings;
 using Domain.Repositories;
 
 namespace Application.MonthlyBillings.UpdatePlan;
@@ -9,16 +8,22 @@ public sealed class UpdatePlanCommandHandler : ICommandHandler<UpdatePlanCommand
 {
     private readonly IMonthlyBillingsRepository _repository;
 
-    public UpdatePlanCommandHandler(IMonthlyBillingsRepository repository)
+    public UpdatePlanCommandHandler(
+        IMonthlyBillingsRepository repository
+    )
     {
-        _repository = repository;
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
     }
 
-    public async Task HandleAsync(UpdatePlanCommand command, CancellationToken cancellationToken = default)
+    public async Task HandleAsync(
+        UpdatePlanCommand command,
+        CancellationToken cancellationToken = default
+    )
     {
-        MonthlyBillingId monthlyBillingId = new(command.MonthlyBillingId);
-        var entity = await _repository.GetById(monthlyBillingId)
-            ?? throw new MonthlyBillingNotFoundException();
+        var entity = await _repository.GetById(
+            new(command.MonthlyBillingId),
+            new(command.UserId)
+        ) ?? throw new MonthlyBillingNotFoundException();
 
         entity.UpdatePlan(
             new(command.PlanId),
@@ -26,7 +31,6 @@ public sealed class UpdatePlanCommandHandler : ICommandHandler<UpdatePlanCommand
             new(command.MoneyAmount, new(command.Currency)),
             command.SortOrder
         );
-
         await _repository.Save(entity);
     }
 }

--- a/src/Domain/MonthlyBillings/MonthlyBilling.cs
+++ b/src/Domain/MonthlyBillings/MonthlyBilling.cs
@@ -1,4 +1,5 @@
 using Domain.Exceptions;
+using Domain.Users;
 
 namespace Domain.MonthlyBillings;
 
@@ -12,6 +13,7 @@ public sealed class MonthlyBilling
     public Month Month { get; }
     public Currency Currency { get; }
     public State State { get; private set; } = State.Open;
+    public UserId UserId { get; private set; }
     public IReadOnlyCollection<Income> Incomes => _incomes.AsReadOnly();
     public IReadOnlyCollection<Plan> Plans => _plans.AsReadOnly();
 
@@ -47,6 +49,7 @@ public sealed class MonthlyBilling
         Month month,
         Currency currency,
         State state,
+        UserId userId,
         List<Plan>? plans = null,
         List<Income>? incomes = null
     )
@@ -55,12 +58,14 @@ public sealed class MonthlyBilling
         ThrowIfYearIsNull(year);
         ThrowIfMonthIsNull(month);
         ThrowIfCurrencyIsNull(currency);
+        ThrowIfUserIdIsNull(userId);
 
         Id = monthlyBillingId;
         Year = year;
         Month = month;
         Currency = currency;
         State = state;    // TODO: Check for null
+        UserId = userId;
 
         _plans = plans ?? new();
         _incomes = incomes ?? new();
@@ -95,6 +100,14 @@ public sealed class MonthlyBilling
         if (currency is null)
         {
             throw new CurrencyIsNullException();
+        }
+    }
+
+    private void ThrowIfUserIdIsNull(UserId userId)
+    {
+        if (userId is null)
+        {
+            throw new UserIdIsNullException();
         }
     }
 

--- a/src/Domain/Repositories/IMonthlyBillingsRepository.cs
+++ b/src/Domain/Repositories/IMonthlyBillingsRepository.cs
@@ -1,10 +1,11 @@
 using Domain.MonthlyBillings;
+using Domain.Users;
 
 namespace Domain.Repositories;
 
 public interface IMonthlyBillingsRepository
 {
-    Task<MonthlyBilling?> Get(Year year, Month month);
-    Task<MonthlyBilling?> GetById(MonthlyBillingId monthlyBillingId);
+    Task<MonthlyBilling?> Get(Year year, Month month, UserId userId);
+    Task<MonthlyBilling?> GetById(MonthlyBillingId monthlyBillingId, UserId userId);
     Task Save(MonthlyBilling monthlyBilling);
 }

--- a/src/Infrastructure/Migrations/20231012201800_Adding UserId to MonthlyBillings.Designer.cs
+++ b/src/Infrastructure/Migrations/20231012201800_Adding UserId to MonthlyBillings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistance;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(SmugetDbContext))]
-    partial class SmugetDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231012201800_Adding UserId to MonthlyBillings")]
+    partial class AddingUserIdtoMonthlyBillings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20231012201800_Adding UserId to MonthlyBillings.cs
+++ b/src/Infrastructure/Migrations/20231012201800_Adding UserId to MonthlyBillings.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddingUserIdtoMonthlyBillings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "UserId",
+                table: "MonthlyBillings",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UserId",
+                table: "MonthlyBillings");
+        }
+    }
+}

--- a/src/Infrastructure/Persistance/Configurations/MonthlyBillingEntityConfirguration.cs
+++ b/src/Infrastructure/Persistance/Configurations/MonthlyBillingEntityConfirguration.cs
@@ -1,5 +1,6 @@
 using Infrastructure.Persistance.Entities;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Infrastructure.Persistance.Configurations;
@@ -32,6 +33,10 @@ internal sealed class MonthlyBillingEntityConfiguration : IEntityTypeConfigurati
 
         builder
             .Property(b => b.State)
+            .IsRequired();
+
+        builder
+            .Property(b => b.UserId)
             .IsRequired();
 
         builder

--- a/src/Infrastructure/Persistance/Configurations/MonthlyBillingEntityConfirguration.cs
+++ b/src/Infrastructure/Persistance/Configurations/MonthlyBillingEntityConfirguration.cs
@@ -1,6 +1,5 @@
 using Infrastructure.Persistance.Entities;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Infrastructure.Persistance.Configurations;

--- a/src/Infrastructure/Persistance/Entities/Mappings/MonthlyBillingMappingExtensions.cs
+++ b/src/Infrastructure/Persistance/Entities/Mappings/MonthlyBillingMappingExtensions.cs
@@ -1,4 +1,5 @@
 using Domain.MonthlyBillings;
+using Domain.Users;
 
 namespace Infrastructure.Persistance.Entities.Mappings;
 
@@ -17,6 +18,7 @@ internal static class MonthlyBillingMappingExtensions
             new Month(entity.Month),
             new Currency(entity.Currency),
             State.GetByName(entity.State),
+            new UserId(entity.UserId),
             entity.Plans
                 .Where(p => p.Active)
                 .ToList()
@@ -41,6 +43,7 @@ internal static class MonthlyBillingMappingExtensions
             Month = domain.Month.Value,
             State = domain.State.ToString(),
             Currency = domain.Currency.Value,
+            UserId = domain.UserId.Value,
             Plans = domain.Plans.Select(
                 p => p.ToEntity(domain.Id.Value)
             )

--- a/src/Infrastructure/Persistance/Entities/MonthlyBillingEntity.cs
+++ b/src/Infrastructure/Persistance/Entities/MonthlyBillingEntity.cs
@@ -7,6 +7,7 @@ internal sealed class MonthlyBillingEntity
     public int Month { get; set; }
     public string State { get; set; }
     public string Currency { get; set; }
+    public Guid UserId { get; set; }
     public List<IncomeEntity> Incomes { get; set; }
     public List<PlanEntity> Plans { get; set; }
 }

--- a/src/Infrastructure/Persistance/Repositories/MonthlyBillingsRepository.cs
+++ b/src/Infrastructure/Persistance/Repositories/MonthlyBillingsRepository.cs
@@ -1,5 +1,6 @@
 using Domain.MonthlyBillings;
 using Domain.Repositories;
+using Domain.Users;
 using Infrastructure.Persistance.Entities;
 using Infrastructure.Persistance.Entities.Mappings;
 using Microsoft.EntityFrameworkCore;
@@ -15,7 +16,11 @@ internal sealed class MonthlyBillingsRepository : IMonthlyBillingsRepository
         _dbContext = dbContext;
     }
 
-    public async Task<MonthlyBilling?> Get(Year year, Month month)
+    public async Task<MonthlyBilling?> Get(
+        Year year,
+        Month month,
+        UserId userId
+    )
     {
         var entites = await _dbContext.MonthlyBillings
             .Include(m => m.Incomes)
@@ -25,13 +30,17 @@ internal sealed class MonthlyBillingsRepository : IMonthlyBillingsRepository
             .FirstOrDefaultAsync(
                 m => m.Year == year.Value
                 && m.Month == month.Value
+                && m.UserId == userId.Value
             );
 
         return entites?
             .ToDomain();
     }
 
-    public async Task<MonthlyBilling?> GetById(MonthlyBillingId monthlyBillingId)
+    public async Task<MonthlyBilling?> GetById(
+        MonthlyBillingId monthlyBillingId,
+        UserId userId
+    )
     {
         var entity = await _dbContext.MonthlyBillings
             .Include(m => m.Incomes)
@@ -40,6 +49,7 @@ internal sealed class MonthlyBillingsRepository : IMonthlyBillingsRepository
             .AsNoTracking()
             .FirstOrDefaultAsync(
                 m => m.Id == monthlyBillingId.Value
+                  && m.UserId == userId.Value
             );
 
         return entity?

--- a/src/WebAPI/Expenses/ExpensesController.cs
+++ b/src/WebAPI/Expenses/ExpensesController.cs
@@ -6,6 +6,7 @@ using Infrastructure.Exceptions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
+using WebAPI.Services.Users;
 using static Microsoft.AspNetCore.Http.StatusCodes;
 
 namespace WebAPI.Expenses;
@@ -20,16 +21,19 @@ public sealed class ExpensesController : ControllerBase
     private readonly ICommandHandler<AddExpenseCommand> _addExpense;
     private readonly ICommandHandler<UpdateExpenseCommand> _updateExpense;
     private readonly ICommandHandler<RemoveExpenseCommand> _removeExpense;
+    private readonly IUserService _userService;
 
     public ExpensesController(
         ICommandHandler<AddExpenseCommand> addExpense,
         ICommandHandler<RemoveExpenseCommand> removeExpense,
-        ICommandHandler<UpdateExpenseCommand> updateExpense
+        ICommandHandler<UpdateExpenseCommand> updateExpense,
+        IUserService userService
     )
     {
         _addExpense = addExpense;
         _updateExpense = updateExpense;
         _removeExpense = removeExpense;
+        _userService = userService;
     }
 
     /// <summary>
@@ -57,7 +61,8 @@ public sealed class ExpensesController : ControllerBase
                 amount,
                 currency,
                 date,
-                description
+                description,
+                _userService.UserId
             ),
             token
         );
@@ -93,7 +98,8 @@ public sealed class ExpensesController : ControllerBase
                 moneyAmount,
                 currency,
                 expenseDate,
-                description
+                description,
+                _userService.UserId
             ),
             token
         );
@@ -122,7 +128,8 @@ public sealed class ExpensesController : ControllerBase
             new RemoveExpenseCommand(
                 monthlyBillingId,
                 planId,
-                expenseId
+                expenseId,
+                _userService.UserId
             ),
             token
         );

--- a/src/WebAPI/Incomes/IncomesController.cs
+++ b/src/WebAPI/Incomes/IncomesController.cs
@@ -5,6 +5,7 @@ using Application.MonthlyBillings.UpdateIncome;
 using Infrastructure.Exceptions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using WebAPI.Services.Users;
 using static Microsoft.AspNetCore.Http.StatusCodes;
 
 namespace WebAPI.Incomes;
@@ -19,16 +20,19 @@ public sealed class IncomesController : ControllerBase
     private readonly ICommandHandler<AddIncomeCommand> _addIncome;
     private readonly ICommandHandler<UpdateIncomeCommand> _updateIncome;
     private readonly ICommandHandler<RemoveIncomeCommand> _removeIncome;
+    private readonly IUserService _userService;
 
     public IncomesController(
         ICommandHandler<AddIncomeCommand> addIncome,
         ICommandHandler<UpdateIncomeCommand> updateIncome,
-        ICommandHandler<RemoveIncomeCommand> removeIncome
+        ICommandHandler<RemoveIncomeCommand> removeIncome,
+        IUserService userService
     )
     {
         _addIncome = addIncome;
         _updateIncome = updateIncome;
         _removeIncome = removeIncome;
+        _userService = userService;
     }
 
     /// <summary>
@@ -53,8 +57,11 @@ public sealed class IncomesController : ControllerBase
                 name,
                 amount,
                 currency,
-                include),
-            token);
+                include,
+                _userService.UserId
+            ),
+            token
+        );
 
         return Created("", null);
     }
@@ -84,7 +91,8 @@ public sealed class IncomesController : ControllerBase
                 name,
                 moneyAmount,
                 currency,
-                include
+                include,
+                _userService.UserId
             ),
             token
         );
@@ -110,7 +118,8 @@ public sealed class IncomesController : ControllerBase
         await _removeIncome.HandleAsync(
             new RemoveIncomeCommand(
                 monthlyBillingId,
-                incomeId
+                incomeId,
+                _userService.UserId
             ),
             token
         );

--- a/src/WebAPI/MonthlyBillings/MonthlyBillingsController.cs
+++ b/src/WebAPI/MonthlyBillings/MonthlyBillingsController.cs
@@ -8,6 +8,7 @@ using Infrastructure.Exceptions;
 using Microsoft.AspNetCore.Mvc;
 using static Microsoft.AspNetCore.Http.StatusCodes;
 using Microsoft.AspNetCore.Authorization;
+using WebAPI.Services.Users;
 
 namespace WebAPI.MonthlyBillings;
 
@@ -22,18 +23,21 @@ public sealed class MonthlyBillingsController : ControllerBase
     private readonly IQueryHandler<GetMonthlyBillingByYearAndMonthQuery, MonthlyBillingDTO> _getMonthlyBilling;
     private readonly ICommandHandler<CloseMonthlyBillingCommand> _closeMonthlyBilling;
     private readonly ICommandHandler<ReopenMonthlyBillingCommand> _reopenMonthlyBilling;
+    private readonly IUserService _userService;
 
     public MonthlyBillingsController(
         ICommandHandler<OpenMonthlyBillingCommand> openMonthlyBilling,
         IQueryHandler<GetMonthlyBillingByYearAndMonthQuery, MonthlyBillingDTO> getMonthlyBilling,
         ICommandHandler<CloseMonthlyBillingCommand> closeMonthlyBilling,
-        ICommandHandler<ReopenMonthlyBillingCommand> reopenMonthlyBilling
+        ICommandHandler<ReopenMonthlyBillingCommand> reopenMonthlyBilling,
+        IUserService userService
     )
     {
         _openMonthlyBilling = openMonthlyBilling;
         _getMonthlyBilling = getMonthlyBilling;
         _closeMonthlyBilling = closeMonthlyBilling;
         _reopenMonthlyBilling = reopenMonthlyBilling;
+        _userService = userService;
     }
 
     /// <summary>
@@ -53,7 +57,8 @@ public sealed class MonthlyBillingsController : ControllerBase
             new OpenMonthlyBillingCommand(
                 year,
                 month,
-                currency
+                currency,
+                _userService.UserId
             ),
             token
         );
@@ -79,7 +84,8 @@ public sealed class MonthlyBillingsController : ControllerBase
         var result = await _getMonthlyBilling.HandleAsync(
             new GetMonthlyBillingByYearAndMonthQuery(
                 year,
-                month
+                month,
+                _userService.UserId
             ),
             token
         );
@@ -105,7 +111,8 @@ public sealed class MonthlyBillingsController : ControllerBase
         await _closeMonthlyBilling.HandleAsync(
             new CloseMonthlyBillingCommand(
                 year,
-                month
+                month,
+                _userService.UserId
             ),
             token
         );
@@ -131,7 +138,8 @@ public sealed class MonthlyBillingsController : ControllerBase
         await _reopenMonthlyBilling.HandleAsync(
             new ReopenMonthlyBillingCommand(
                 year,
-                month
+                month,
+                _userService.UserId
             ),
             token
         );

--- a/src/WebAPI/Plans/PlansController.cs
+++ b/src/WebAPI/Plans/PlansController.cs
@@ -5,6 +5,7 @@ using Application.MonthlyBillings.UpdatePlan;
 using Infrastructure.Exceptions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using WebAPI.Services.Users;
 using static Microsoft.AspNetCore.Http.StatusCodes;
 
 namespace WebAPI.Plans;
@@ -19,16 +20,19 @@ public sealed class PlansController : ControllerBase
     private readonly ICommandHandler<AddPlanCommand> _addPlan;
     private readonly ICommandHandler<UpdatePlanCommand> _updatePlan;
     private readonly ICommandHandler<RemovePlanCommand> _removePlan;
+    private readonly IUserService _userService;
 
     public PlansController(
         ICommandHandler<AddPlanCommand> addPlan,
         ICommandHandler<UpdatePlanCommand> updatePlan,
-        ICommandHandler<RemovePlanCommand> removePlan
+        ICommandHandler<RemovePlanCommand> removePlan,
+        IUserService userService
     )
     {
         _addPlan = addPlan;
         _updatePlan = updatePlan;
         _removePlan = removePlan;
+        _userService = userService;
     }
 
     /// <summary>
@@ -53,8 +57,11 @@ public sealed class PlansController : ControllerBase
                 category,
                 amount,
                 currency,
-                sortOrder),
-            token);
+                sortOrder,
+                _userService.UserId
+            ),
+            token
+        );
 
         return Created("", null);
     }
@@ -84,7 +91,8 @@ public sealed class PlansController : ControllerBase
                 category,
                 moneyAmount,
                 currency,
-                sortOrder
+                sortOrder,
+                _userService.UserId
             ),
             token
         );
@@ -110,7 +118,8 @@ public sealed class PlansController : ControllerBase
         await _removePlan.HandleAsync(
             new RemovePlanCommand(
                 monthlyBillingId,
-                planId
+                planId,
+                _userService.UserId
             ),
             token
         );

--- a/src/WebAPI/Program.cs
+++ b/src/WebAPI/Program.cs
@@ -1,13 +1,17 @@
 using System.Reflection;
 using Application;
 using Infrastructure;
+using WebAPI;
 using WebAPI.Middlewares;
+using WebAPI.Services.Users;
 
 var builder = WebApplication.CreateBuilder(args);
 {
     builder.Services
         .AddApplication()
         .AddInfrastructure(builder.Configuration);
+
+    builder.Services.AddScoped<IUserService, UserService>();
 
     builder.Services.AddHTTPLogging();
 

--- a/src/WebAPI/Services/Users/IUserService.cs
+++ b/src/WebAPI/Services/Users/IUserService.cs
@@ -1,0 +1,6 @@
+namespace WebAPI.Services.Users;
+
+public interface IUserService
+{
+    Guid UserId { get; }
+}

--- a/src/WebAPI/Services/Users/UserIdentityNotFoundException.cs
+++ b/src/WebAPI/Services/Users/UserIdentityNotFoundException.cs
@@ -1,0 +1,9 @@
+using Domain.Exceptions;
+
+namespace WebAPI.Services.Users;
+
+public sealed class UserIdentityNotFoundException : SmugetException
+{
+    public UserIdentityNotFoundException()
+        : base("User not authorized.") { }
+}

--- a/src/WebAPI/Services/Users/UserService.cs
+++ b/src/WebAPI/Services/Users/UserService.cs
@@ -1,0 +1,15 @@
+namespace WebAPI.Services.Users;
+
+public sealed class UserService : IUserService
+{
+    private readonly HttpContext _httpContext;
+
+    public UserService(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContext = httpContextAccessor.HttpContext ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+    }
+
+    public Guid UserId
+        => Guid.Parse(_httpContext.User.Identity?.Name
+            ?? throw new UserIdentityNotFoundException());
+}

--- a/tests/Application.Unit.Tests/MonthlyBillings/AddExpense/AddExpenseCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/AddExpense/AddExpenseCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using Application.Unit.Tests.TestUtilities;
 using Application.Unit.Tests.TestUtilities.Constants;
 using Domain.MonthlyBillings;
 using Domain.Repositories;
+using Domain.Users;
 
 namespace Application.Unit.Tests.MonthlyBillings.AddExpense;
 
@@ -18,7 +19,10 @@ public sealed class AddExpenseCommandHandlerTests
         _repository = Substitute.For<IMonthlyBillingsRepository>();
 
         _repository
-            .GetById(new(Constants.MonthlyBilling.Id))
+            .GetById(
+                new(Constants.MonthlyBilling.Id),
+                new(Constants.User.Id)
+            )
             .Returns(MonthlyBillingUtilities.CreateMonthlyBilling());
 
         _handler = new AddExpenseCommandHandler(_repository);
@@ -40,7 +44,8 @@ public sealed class AddExpenseCommandHandlerTests
         await _repository
             .Received(1)
             .GetById(
-                Arg.Is<MonthlyBillingId>(id => id.Value == addExpenseCommand.MonthlyBillingId)
+                Arg.Is<MonthlyBillingId>(id => id.Value == addExpenseCommand.MonthlyBillingId),
+                Arg.Is<UserId>(u => u.Value == addExpenseCommand.UserId)
             );
     }
 
@@ -54,7 +59,8 @@ public sealed class AddExpenseCommandHandlerTests
             Constants.Expense.Money,
             Constants.Expense.Currency,
             Constants.Expense.ExpenseDate,
-            Constants.Expense.Description
+            Constants.Expense.Description,
+            Constants.User.Id
         );
 
         var addExpense = () => _handler.HandleAsync(

--- a/tests/Application.Unit.Tests/MonthlyBillings/AddExpense/AddExpenseCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/AddExpense/AddExpenseCommandUtilities.cs
@@ -12,6 +12,7 @@ public static class AddExpenseCommandUtilities
             Constants.Expense.Money,
             Constants.Expense.Currency,
             Constants.Expense.ExpenseDate,
-            Constants.Expense.Description
+            Constants.Expense.Description,
+            Constants.User.Id
         );
 }

--- a/tests/Application.Unit.Tests/MonthlyBillings/AddIncome/AddIncomeCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/AddIncome/AddIncomeCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using Domain.Repositories;
 using Application.Unit.Tests.TestUtilities.Constants;
 using Application.Unit.Tests.TestUtilities;
 using Application.Exceptions;
+using Domain.Users;
 
 namespace Application.Unit.Tests.MonthlyBillings.AddIncome;
 
@@ -18,7 +19,10 @@ public sealed class AddIncomeCommandHandlerTests
         _repository = Substitute.For<IMonthlyBillingsRepository>();
 
         _repository
-            .GetById(new(Constants.MonthlyBilling.Id))
+            .GetById(
+                new(Constants.MonthlyBilling.Id),
+                new(Constants.User.Id)
+            )
             .Returns(MonthlyBillingUtilities.CreateMonthlyBilling());
 
         _handler = new AddIncomeCommandHandler(_repository);
@@ -40,7 +44,8 @@ public sealed class AddIncomeCommandHandlerTests
         await _repository
             .Received(1)
             .GetById(
-                Arg.Is<MonthlyBillingId>(id => id.Value == addIncomeCommand.MonthlyBillingId)
+                Arg.Is<MonthlyBillingId>(id => id.Value == addIncomeCommand.MonthlyBillingId),
+                Arg.Is<UserId>(u => u.Value == addIncomeCommand.UserId)
             );
     }
 
@@ -53,7 +58,8 @@ public sealed class AddIncomeCommandHandlerTests
             Constants.Income.Name,
             Constants.Income.Amount,
             Constants.Income.Currency,
-            Constants.Income.Include
+            Constants.Income.Include,
+            Constants.User.Id
         );
 
         var addIncome = () => _handler.HandleAsync(

--- a/tests/Application.Unit.Tests/MonthlyBillings/AddIncome/AddIncomeCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/AddIncome/AddIncomeCommandUtilities.cs
@@ -11,6 +11,7 @@ public static class AddIncomeCommandUtilities
             Constants.Income.Name,
             Constants.Income.Amount,
             Constants.Income.Currency,
-            Constants.Income.Include
+            Constants.Income.Include,
+            Constants.User.Id
         );
 }

--- a/tests/Application.Unit.Tests/MonthlyBillings/AddPlan/AddPlanCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/AddPlan/AddPlanCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using Application.Unit.Tests.TestUtilities;
 using Application.Unit.Tests.TestUtilities.Constants;
 using Domain.MonthlyBillings;
 using Domain.Repositories;
+using Domain.Users;
 
 namespace Application.Unit.Tests.MonthlyBillings.AddPlan;
 
@@ -18,7 +19,10 @@ public sealed class AddPlanCommandHandlerTests
         _repository = Substitute.For<IMonthlyBillingsRepository>();
 
         _repository
-            .GetById(new(Constants.MonthlyBilling.Id))
+            .GetById(
+                new(Constants.MonthlyBilling.Id),
+                new(Constants.User.Id)
+            )
             .Returns(MonthlyBillingUtilities.CreateMonthlyBilling());
 
         _handler = new AddPlanCommandHandler(_repository);
@@ -39,9 +43,10 @@ public sealed class AddPlanCommandHandlerTests
         // Assert
         await _repository
             .Received(1)
-            .GetById(Arg.Is<MonthlyBillingId>(
-                m => m.Value == addPlanCommand.MonthlyBillingId
-            ));
+            .GetById(
+                Arg.Is<MonthlyBillingId>(m => m.Value == addPlanCommand.MonthlyBillingId),
+                Arg.Is<UserId>(u => u.Value == addPlanCommand.UserId)
+            );
     }
 
     [Fact]
@@ -53,7 +58,8 @@ public sealed class AddPlanCommandHandlerTests
             Constants.Plan.Category,
             Constants.Plan.MoneyAmount,
             Constants.Plan.Currency,
-            Constants.Plan.SortOrder
+            Constants.Plan.SortOrder,
+            Constants.User.Id
         );
 
         var addPlan = () => _handler.HandleAsync(

--- a/tests/Application.Unit.Tests/MonthlyBillings/AddPlan/AddPlanCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/AddPlan/AddPlanCommandUtilities.cs
@@ -11,6 +11,7 @@ public static class AddPlanCommandUtilities
             Constants.Plan.Category,
             Constants.Plan.MoneyAmount,
             Constants.Plan.Currency,
-            Constants.Plan.SortOrder
+            Constants.Plan.SortOrder,
+            Constants.User.Id
         );
 }

--- a/tests/Application.Unit.Tests/MonthlyBillings/CloseMonthlyBilling/CloseMonthlyBillingCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/CloseMonthlyBilling/CloseMonthlyBillingCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using Application.Unit.Tests.TestUtilities;
 using Application.Unit.Tests.TestUtilities.Constants;
 using Domain.MonthlyBillings;
 using Domain.Repositories;
+using Domain.Users;
 
 namespace Application.Unit.Tests.MonthlyBillings.CloseMonthlyBilling;
 
@@ -20,7 +21,8 @@ public sealed class CloseMonthlyBillingCommandHandlerTests
         _repository
             .Get(
                 new(Constants.MonthlyBilling.Year),
-                new(Constants.MonthlyBilling.Month)
+                new(Constants.MonthlyBilling.Month),
+                new(Constants.User.Id)
             )
             .Returns(MonthlyBillingUtilities.CreateMonthlyBilling());
 
@@ -44,7 +46,8 @@ public sealed class CloseMonthlyBillingCommandHandlerTests
             .Received(1)
             .Get(
                 Arg.Is<Year>(y => y.Value == closeCommand.Year),
-                Arg.Is<Month>(m => m.Value == closeCommand.Month)
+                Arg.Is<Month>(m => m.Value == closeCommand.Month),
+                Arg.Is<UserId>(u => u.Value == closeCommand.UserId)
             );
     }
 
@@ -54,7 +57,8 @@ public sealed class CloseMonthlyBillingCommandHandlerTests
         // Arrange
         var closeCommand = new CloseMonthlyBillingCommand(
             2000,
-            1
+            1,
+            Constants.User.Id
         );
 
         var closeAction = () => _handler.HandleAsync(

--- a/tests/Application.Unit.Tests/MonthlyBillings/CloseMonthlyBilling/CloseMonthlyBillingCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/CloseMonthlyBilling/CloseMonthlyBillingCommandUtilities.cs
@@ -8,6 +8,7 @@ public static class CloseMonthlyBillingCommandUtilities
     public static CloseMonthlyBillingCommand CreateCommand()
         => new(
             Constants.MonthlyBilling.Year,
-            Constants.MonthlyBilling.Month
+            Constants.MonthlyBilling.Month,
+            Constants.User.Id
         );
 }

--- a/tests/Application.Unit.Tests/MonthlyBillings/GetByYearAndMonth/GetByYearAndMonthQueryHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/GetByYearAndMonth/GetByYearAndMonthQueryHandlerTests.cs
@@ -8,6 +8,7 @@ using Application.Unit.Tests.TestUtilities;
 using Application.Unit.Tests.TestUtilities.Constants;
 using Domain.MonthlyBillings;
 using Domain.Repositories;
+using Domain.Users;
 
 namespace Application.Unit.Tests.MonthlyBillings.GetByYearAndMonth;
 
@@ -23,7 +24,8 @@ public sealed class GetByYearAndMonthQueryHandlerTests
         _repository
             .Get(
                 new(Constants.MonthlyBilling.Year),
-                new(Constants.MonthlyBilling.Month)
+                new(Constants.MonthlyBilling.Month),
+                new(Constants.User.Id)
             )
             .Returns(MonthlyBillingUtilities.CreateMonthlyBilling(
                 plans: new List<Plan>() { PlansUtilities.CreatePlan(
@@ -52,7 +54,8 @@ public sealed class GetByYearAndMonthQueryHandlerTests
             .Received(1)
             .Get(
                 Arg.Is<Year>(y => y.Value == getQuery.Year),
-                Arg.Is<Month>(m => m.Value == getQuery.Month)
+                Arg.Is<Month>(m => m.Value == getQuery.Month),
+                Arg.Is<UserId>(m => m.Value == getQuery.UserId)
             );
     }
 
@@ -62,7 +65,8 @@ public sealed class GetByYearAndMonthQueryHandlerTests
         // Arrange
         var getQuery = new GetMonthlyBillingByYearAndMonthQuery(
             2020,
-            1
+            1,
+            Constants.User.Id
         );
 
         var getAction = () => _handler.HandleAsync(
@@ -93,10 +97,10 @@ public sealed class GetByYearAndMonthQueryHandlerTests
 
         result
             .Should()
-            .BeEquivalentTo(ExpectedMonthlyBillingDTO2());
+            .BeEquivalentTo(ExpectedMonthlyBillingDTO());
     }
 
-    private MonthlyBillingDTO ExpectedMonthlyBillingDTO2()
+    private MonthlyBillingDTO ExpectedMonthlyBillingDTO()
         => new MonthlyBillingDTO()
         {
             Id = Constants.MonthlyBilling.Id,

--- a/tests/Application.Unit.Tests/MonthlyBillings/GetByYearAndMonth/GetByYearAndMonthQueryHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/GetByYearAndMonth/GetByYearAndMonthQueryHandlerTests.cs
@@ -55,7 +55,7 @@ public sealed class GetByYearAndMonthQueryHandlerTests
             .Get(
                 Arg.Is<Year>(y => y.Value == getQuery.Year),
                 Arg.Is<Month>(m => m.Value == getQuery.Month),
-                Arg.Is<UserId>(m => m.Value == getQuery.UserId)
+                Arg.Is<UserId>(u => u.Value == getQuery.UserId)
             );
     }
 

--- a/tests/Application.Unit.Tests/MonthlyBillings/GetByYearAndMonth/GetMonthlyBillingByYearAndMonthQueryUtilities.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/GetByYearAndMonth/GetMonthlyBillingByYearAndMonthQueryUtilities.cs
@@ -8,6 +8,7 @@ public static class GetMonthlyBillingByYearAndMonthQueryUtilities
     public static GetMonthlyBillingByYearAndMonthQuery CreateQuery()
         => new(
             Constants.MonthlyBilling.Year,
-            Constants.MonthlyBilling.Month
+            Constants.MonthlyBilling.Month,
+            Constants.User.Id
         );
 }

--- a/tests/Application.Unit.Tests/MonthlyBillings/OpenMonthlyBiling/OpenMonthlyBillingCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/OpenMonthlyBiling/OpenMonthlyBillingCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using Application.Exceptions;
 using Application.MonthlyBillings.OpenMonthlyBilling;
 using Application.Unit.Tests.MonthlyBillings.TestUtilities;
@@ -20,7 +21,8 @@ public sealed class OpenMonthlyBilingCommandHandlerTests
         _repository
             .Get(
                 new(Constants.MonthlyBilling.Year),
-                new(Constants.MonthlyBilling.Month)
+                new(Constants.MonthlyBilling.Month),
+                new(Constants.User.Id)
             )
             .Returns(MonthlyBillingUtilities.CreateMonthlyBilling());
 
@@ -44,7 +46,8 @@ public sealed class OpenMonthlyBilingCommandHandlerTests
             .Received(1)
             .Get(
                 new(openCommand.Year),
-                new(openCommand.Month)
+                new(openCommand.Month),
+                new(openCommand.UserId)
             );
     }
 
@@ -55,7 +58,8 @@ public sealed class OpenMonthlyBilingCommandHandlerTests
         var openCommand = new OpenMonthlyBillingCommand(
             Constants.MonthlyBilling.Year,
             Constants.MonthlyBilling.Month,
-            Constants.MonthlyBilling.Currency
+            Constants.MonthlyBilling.Currency,
+            Constants.User.Id
         );
 
         var openAction = () => _handler.HandleAsync(
@@ -101,7 +105,7 @@ public sealed class OpenMonthlyBilingCommandHandlerTests
             openCommand,
             default
         );
-        
+
         // Assert
         passedArgument
             .Should()
@@ -122,5 +126,9 @@ public sealed class OpenMonthlyBilingCommandHandlerTests
         passedArgument?.Currency.Value
             .Should()
             .Be(openCommand.Currency);
+
+        passedArgument?.UserId.Value
+            .Should()
+            .Be(openCommand.UserId);
     }
 }

--- a/tests/Application.Unit.Tests/MonthlyBillings/OpenMonthlyBiling/OpenMonthlyBillingCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/OpenMonthlyBiling/OpenMonthlyBillingCommandUtilities.cs
@@ -9,6 +9,7 @@ public static class OpenMonthlyBilingCommandUtilities
         => new (
             Constants.MonthlyBilling.Year + 1,
             Constants.MonthlyBilling.Month + 1,
-            Constants.MonthlyBilling.Currency
+            Constants.MonthlyBilling.Currency,
+            Constants.User.Id
         );
 }

--- a/tests/Application.Unit.Tests/MonthlyBillings/RemoveExpense/RemoveExpenseCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/RemoveExpense/RemoveExpenseCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using Application.Unit.Tests.TestUtilities;
 using Application.Unit.Tests.TestUtilities.Constants;
 using Domain.MonthlyBillings;
 using Domain.Repositories;
+using Domain.Users;
 
 namespace Application.Unit.Tests.MonthlyBillings.RemoveExpense;
 
@@ -18,7 +19,10 @@ public sealed class RemoveExpenseCommandHandlerTests
         _repository = Substitute.For<IMonthlyBillingsRepository>();
 
         _repository
-            .GetById(new(Constants.MonthlyBilling.Id))
+            .GetById(
+                new(Constants.MonthlyBilling.Id),
+                new(Constants.User.Id)
+            )
             .Returns(MonthlyBillingUtilities.CreateMonthlyBilling());
 
         _handler = new RemoveExpenseCommandHandler(_repository);
@@ -40,9 +44,8 @@ public sealed class RemoveExpenseCommandHandlerTests
         await _repository
             .Received(1)
             .GetById(
-                Arg.Is<MonthlyBillingId>(
-                    m => m.Value == removeExpense.MonthlyBillingId
-                )
+                Arg.Is<MonthlyBillingId>(m => m.Value == removeExpense.MonthlyBillingId),
+                Arg.Is<UserId>(m => m.Value == removeExpense.UserId)
             );
     }
 
@@ -53,7 +56,8 @@ public sealed class RemoveExpenseCommandHandlerTests
         var removeExpense = new RemoveExpenseCommand(
             Guid.NewGuid(),
             Constants.Plan.Id,
-            Constants.Expense.Id
+            Constants.Expense.Id,
+            Constants.User.Id
         );
 
         var removeAction = () => _handler.HandleAsync(

--- a/tests/Application.Unit.Tests/MonthlyBillings/RemoveExpense/RemoveExpenseCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/RemoveExpense/RemoveExpenseCommandHandlerTests.cs
@@ -45,7 +45,7 @@ public sealed class RemoveExpenseCommandHandlerTests
             .Received(1)
             .GetById(
                 Arg.Is<MonthlyBillingId>(m => m.Value == removeExpense.MonthlyBillingId),
-                Arg.Is<UserId>(m => m.Value == removeExpense.UserId)
+                Arg.Is<UserId>(u => u.Value == removeExpense.UserId)
             );
     }
 

--- a/tests/Application.Unit.Tests/MonthlyBillings/RemoveExpense/RemoveExpenseCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/RemoveExpense/RemoveExpenseCommandUtilities.cs
@@ -9,6 +9,7 @@ public static class RemoveExpenseCommandUtilities
         => new(
             Constants.MonthlyBilling.Id,
             Constants.Plan.Id,
-            Constants.Expense.Id
+            Constants.Expense.Id,
+            Constants.User.Id
         );
 }

--- a/tests/Application.Unit.Tests/MonthlyBillings/RemoveIncome/RemoveIncomeCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/RemoveIncome/RemoveIncomeCommandHandlerTests.cs
@@ -46,7 +46,7 @@ public sealed class RemoveIncomeCommandHandlerTests
             .Received(1)
             .GetById(
                 Arg.Is<MonthlyBillingId>(m => m.Value == command.MonthlyBillingId),
-                Arg.Is<UserId>(m => m.Value == command.UserId)
+                Arg.Is<UserId>(u => u.Value == command.UserId)
             );
     }
 

--- a/tests/Application.Unit.Tests/MonthlyBillings/RemoveIncome/RemoveIncomeCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/RemoveIncome/RemoveIncomeCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using Application.Unit.Tests.TestUtilities.Constants;
 using Application.Unit.Tests.TestUtilities;
 using Domain.MonthlyBillings;
 using Domain.Repositories;
+using Domain.Users;
 
 namespace Application.Unit.Tests.MonthlyBillings.RemoveIncome;
 
@@ -18,7 +19,10 @@ public sealed class RemoveIncomeCommandHandlerTests
         _repository = Substitute.For<IMonthlyBillingsRepository>();
 
         _repository
-            .GetById(new(Constants.MonthlyBilling.Id))
+            .GetById(
+                new(Constants.MonthlyBilling.Id),
+                new(Constants.User.Id)
+            )
             .Returns(MonthlyBillingUtilities.CreateMonthlyBilling());
 
         _handler = new RemoveIncomeCommandHandler(_repository);
@@ -40,7 +44,10 @@ public sealed class RemoveIncomeCommandHandlerTests
         // Assert
         await _repository
             .Received(1)
-            .GetById(Arg.Is<MonthlyBillingId>(m => m.Value == command.MonthlyBillingId));
+            .GetById(
+                Arg.Is<MonthlyBillingId>(m => m.Value == command.MonthlyBillingId),
+                Arg.Is<UserId>(m => m.Value == command.UserId)
+            );
     }
 
     [Fact]
@@ -49,7 +56,8 @@ public sealed class RemoveIncomeCommandHandlerTests
         // Arrange
         var removeIncome = new RemoveIncomeCommand(
             Guid.NewGuid(),
-            Constants.Income.Id
+            Constants.Income.Id,
+            Constants.User.Id
         );
 
         var removeIncomeAction = async () => await _handler

--- a/tests/Application.Unit.Tests/MonthlyBillings/RemoveIncome/RemoveIncomeCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/RemoveIncome/RemoveIncomeCommandUtilities.cs
@@ -8,6 +8,7 @@ public static class RemoveIncomeCommandUtilities
     public static RemoveIncomeCommand CreateCommand()
         => new(
             Constants.MonthlyBilling.Id,
-            Constants.Income.Id
+            Constants.Income.Id,
+            Constants.User.Id
         );
 }

--- a/tests/Application.Unit.Tests/MonthlyBillings/RemovePlan/RemovePlanCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/RemovePlan/RemovePlanCommandHandlerTests.cs
@@ -46,7 +46,7 @@ public sealed class RemovePlanCommandHandlerTests
             .Received(1)
             .GetById(
                 Arg.Is<MonthlyBillingId>(m => m.Value == removePlan.MonthlyBillingId),
-                Arg.Is<UserId>(m => m.Value == removePlan.UserId)
+                Arg.Is<UserId>(u => u.Value == removePlan.UserId)
             );
     }
 

--- a/tests/Application.Unit.Tests/MonthlyBillings/RemovePlan/RemovePlanCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/RemovePlan/RemovePlanCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using Application.Unit.Tests.TestUtilities;
 using Application.Unit.Tests.TestUtilities.Constants;
 using Domain.MonthlyBillings;
 using Domain.Repositories;
+using Domain.Users;
 
 namespace Application.Unit.Tests.MonthlyBillings.RemovePlan;
 
@@ -18,7 +19,10 @@ public sealed class RemovePlanCommandHandlerTests
         _repository = Substitute.For<IMonthlyBillingsRepository>();
 
         _repository
-            .GetById(new(Constants.MonthlyBilling.Id))
+            .GetById(
+                new(Constants.MonthlyBilling.Id),
+                new(Constants.User.Id)
+            )
             .Returns(MonthlyBillingUtilities.CreateMonthlyBilling());
 
         _handler = new RemovePlanCommandHandler(_repository);
@@ -40,7 +44,10 @@ public sealed class RemovePlanCommandHandlerTests
         // Assert
         await _repository
             .Received(1)
-            .GetById(Arg.Is<MonthlyBillingId>(m => m.Value == removePlan.MonthlyBillingId));
+            .GetById(
+                Arg.Is<MonthlyBillingId>(m => m.Value == removePlan.MonthlyBillingId),
+                Arg.Is<UserId>(m => m.Value == removePlan.UserId)
+            );
     }
 
     [Fact]
@@ -49,7 +56,8 @@ public sealed class RemovePlanCommandHandlerTests
         // Arrange
         var removePlan = new RemovePlanCommand(
             Guid.NewGuid(),
-            Constants.Plan.Id
+            Constants.Plan.Id,
+            Constants.User.Id
         );
 
         var removePlanAction = () => _handler

--- a/tests/Application.Unit.Tests/MonthlyBillings/RemovePlan/RemovePlanCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/RemovePlan/RemovePlanCommandUtilities.cs
@@ -8,6 +8,7 @@ public static class RemovePlanCommandUtilities
     public static RemovePlanCommand CreateCommand()
         => new(
             Constants.MonthlyBilling.Id,
-            Constants.Plan.Id
+            Constants.Plan.Id,
+            Constants.User.Id
         );
 }

--- a/tests/Application.Unit.Tests/MonthlyBillings/ReopenMonthlyBilling/ReopenMonthlyBillingCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/ReopenMonthlyBilling/ReopenMonthlyBillingCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using Application.Unit.Tests.TestUtilities;
 using Application.Unit.Tests.TestUtilities.Constants;
 using Domain.MonthlyBillings;
 using Domain.Repositories;
+using Domain.Users;
 
 namespace Application.Unit.Tests.MonthlyBillings.ReopenMonthlyBilling;
 
@@ -24,7 +25,8 @@ public sealed class ReopenMonthlyBillingCommandHandlerTests
         _repository
             .Get(
                 new(Constants.MonthlyBilling.Year),
-                new(Constants.MonthlyBilling.Month)
+                new(Constants.MonthlyBilling.Month),
+                new(Constants.User.Id)
             )
             .Returns(fakeMonthlyBilling);
 
@@ -48,7 +50,8 @@ public sealed class ReopenMonthlyBillingCommandHandlerTests
             .Received(1)
             .Get(
                 Arg.Is<Year>(y => y.Value == reopen.Year),
-                Arg.Is<Month>(m => m.Value == reopen.Month)
+                Arg.Is<Month>(m => m.Value == reopen.Month),
+                Arg.Is<UserId>(m => m.Value == reopen.UserId)
             );
     }
 
@@ -58,7 +61,8 @@ public sealed class ReopenMonthlyBillingCommandHandlerTests
         // Arrange
         var reopen = new ReopenMonthlyBillingCommand(
             2020,
-            1
+            1,
+            Constants.User.Id
         );
 
         var reopenAction = () => _handler.HandleAsync(

--- a/tests/Application.Unit.Tests/MonthlyBillings/ReopenMonthlyBilling/ReopenMonthlyBillingCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/ReopenMonthlyBilling/ReopenMonthlyBillingCommandUtilities.cs
@@ -8,6 +8,7 @@ public static class ReopenMonthlyBillingCommandUtilities
     public static ReopenMonthlyBillingCommand CreateCommand()
         => new(
             Constants.MonthlyBilling.Year,
-            Constants.MonthlyBilling.Month
+            Constants.MonthlyBilling.Month,
+            Constants.User.Id
         );
 }

--- a/tests/Application.Unit.Tests/MonthlyBillings/UpdateExpense/UpdateExpenseCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/UpdateExpense/UpdateExpenseCommandHandlerTests.cs
@@ -45,7 +45,7 @@ public sealed class UpdateExpenseCommandHandlerTests
             .Received(1)
             .GetById(
                 Arg.Is<MonthlyBillingId>(m => m.Value == command.MonthlyBillingId),
-                Arg.Is<UserId>(m => m.Value == command.UserId)
+                Arg.Is<UserId>(u => u.Value == command.UserId)
             );
     }
 

--- a/tests/Application.Unit.Tests/MonthlyBillings/UpdateExpense/UpdateExpenseCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/UpdateExpense/UpdateExpenseCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using Application.Unit.Tests.TestUtilities;
 using Application.Unit.Tests.TestUtilities.Constants;
 using Domain.MonthlyBillings;
 using Domain.Repositories;
+using Domain.Users;
 
 namespace Application.Unit.Tests.MonthlyBillings.UpdateExpense;
 
@@ -18,7 +19,10 @@ public sealed class UpdateExpenseCommandHandlerTests
         _repository = Substitute.For<IMonthlyBillingsRepository>();
 
         _repository
-            .GetById(new(Constants.MonthlyBilling.Id))
+            .GetById(
+                new(Constants.MonthlyBilling.Id),
+                new(Constants.User.Id)
+            )
             .Returns(MonthlyBillingUtilities.CreateMonthlyBilling());
 
         _handler = new UpdateExpenseCommandHandler(_repository);
@@ -39,7 +43,10 @@ public sealed class UpdateExpenseCommandHandlerTests
         // Act & Assert
         await _repository
             .Received(1)
-            .GetById(Arg.Is<MonthlyBillingId>(m => m.Value == command.MonthlyBillingId));
+            .GetById(
+                Arg.Is<MonthlyBillingId>(m => m.Value == command.MonthlyBillingId),
+                Arg.Is<UserId>(m => m.Value == command.UserId)
+            );
     }
 
     [Fact]
@@ -53,7 +60,8 @@ public sealed class UpdateExpenseCommandHandlerTests
             Constants.Expense.Money,
             Constants.Expense.Currency,
             Constants.Expense.ExpenseDate,
-            Constants.Expense.Description
+            Constants.Expense.Description,
+            Constants.User.Id
         );
 
         var updateExpenseAction = () => _handler.HandleAsync(

--- a/tests/Application.Unit.Tests/MonthlyBillings/UpdateExpense/UpdateExpenseCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/UpdateExpense/UpdateExpenseCommandUtilities.cs
@@ -13,6 +13,7 @@ public static class UpdateExpenseCommandUtilities
             456.42m,
             "USD",
             new DateTimeOffset(new DateTime(2023, 9, 11, 13, 43, 22)),
-            "Updated description"
+            "Updated description",
+            Constants.User.Id
         );
 }

--- a/tests/Application.Unit.Tests/MonthlyBillings/UpdateIncome/UpdateIncomeCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/UpdateIncome/UpdateIncomeCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using Application.Unit.Tests.TestUtilities;
 using Application.Unit.Tests.TestUtilities.Constants;
 using Domain.MonthlyBillings;
 using Domain.Repositories;
+using Domain.Users;
 
 namespace Application.Unit.Tests.MonthlyBillings.UpdateIncome;
 
@@ -18,7 +19,10 @@ public sealed class UpdateIncomeCommandHandlerTests
         _repository = Substitute.For<IMonthlyBillingsRepository>();
 
         _repository
-            .GetById(new(Constants.MonthlyBilling.Id))
+            .GetById(
+                new(Constants.MonthlyBilling.Id),
+                new(Constants.User.Id)
+            )
             .Returns(MonthlyBillingUtilities.CreateMonthlyBilling());
 
         _handler = new UpdateIncomeCommandHandler(_repository);
@@ -39,7 +43,10 @@ public sealed class UpdateIncomeCommandHandlerTests
         // Act & Assert
         await _repository
             .Received(1)
-            .GetById(Arg.Is<MonthlyBillingId>(m => m.Value == updateIncome.MonthlyBillingId));
+            .GetById(
+                Arg.Is<MonthlyBillingId>(m => m.Value == updateIncome.MonthlyBillingId),
+                Arg.Is<UserId>(m => m.Value == updateIncome.UserId)
+            );
     }
 
     [Fact]
@@ -52,7 +59,8 @@ public sealed class UpdateIncomeCommandHandlerTests
             Constants.Income.Name,
             Constants.Income.Amount,
             Constants.Income.Currency,
-            Constants.Income.Include
+            Constants.Income.Include,
+            Constants.User.Id
         );
 
         var updateIncomeAction = () => _handler.HandleAsync(

--- a/tests/Application.Unit.Tests/MonthlyBillings/UpdateIncome/UpdateIncomeCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/UpdateIncome/UpdateIncomeCommandHandlerTests.cs
@@ -45,7 +45,7 @@ public sealed class UpdateIncomeCommandHandlerTests
             .Received(1)
             .GetById(
                 Arg.Is<MonthlyBillingId>(m => m.Value == updateIncome.MonthlyBillingId),
-                Arg.Is<UserId>(m => m.Value == updateIncome.UserId)
+                Arg.Is<UserId>(u => u.Value == updateIncome.UserId)
             );
     }
 

--- a/tests/Application.Unit.Tests/MonthlyBillings/UpdateIncome/UpdateIncomeCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/UpdateIncome/UpdateIncomeCommandUtilities.cs
@@ -12,6 +12,7 @@ public static class UpdateIncomeCommandUtilities
             "Updated Name Income",
             1234.56m,
             "EUR",
-            false
+            false,
+            Constants.User.Id
         );
 }

--- a/tests/Application.Unit.Tests/MonthlyBillings/UpdatePlan/UpdatePlanCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/UpdatePlan/UpdatePlanCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using Application.Unit.Tests.TestUtilities;
 using Application.Unit.Tests.TestUtilities.Constants;
 using Domain.MonthlyBillings;
 using Domain.Repositories;
+using Domain.Users;
 
 namespace Application.Unit.Tests.MonthlyBillings.UpdatePlan;
 
@@ -18,7 +19,10 @@ public sealed class UpdatePlanCommandHandlerTests
         _repository = Substitute.For<IMonthlyBillingsRepository>();
 
         _repository
-            .GetById(new(Constants.MonthlyBilling.Id))
+            .GetById(
+                new(Constants.MonthlyBilling.Id),
+                new(Constants.User.Id)
+            )
             .Returns(MonthlyBillingUtilities.CreateMonthlyBilling());
 
         _handler = new UpdatePlanCommandHandler(_repository);
@@ -39,7 +43,10 @@ public sealed class UpdatePlanCommandHandlerTests
         // Assert
         await _repository
             .Received(1)
-            .GetById(Arg.Is<MonthlyBillingId>(m => m.Value == command.MonthlyBillingId));
+            .GetById(
+                Arg.Is<MonthlyBillingId>(m => m.Value == command.MonthlyBillingId),
+                Arg.Is<UserId>(m => m.Value == command.UserId)
+            );
     }
 
     [Fact]
@@ -52,7 +59,8 @@ public sealed class UpdatePlanCommandHandlerTests
             Constants.Plan.Category,
             Constants.Plan.MoneyAmount,
             Constants.Plan.Currency,
-            Constants.Plan.SortOrder
+            Constants.Plan.SortOrder,
+            Constants.User.Id
         );
 
         var updatePlanAction = () => _handler

--- a/tests/Application.Unit.Tests/MonthlyBillings/UpdatePlan/UpdatePlanCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/UpdatePlan/UpdatePlanCommandHandlerTests.cs
@@ -45,7 +45,7 @@ public sealed class UpdatePlanCommandHandlerTests
             .Received(1)
             .GetById(
                 Arg.Is<MonthlyBillingId>(m => m.Value == command.MonthlyBillingId),
-                Arg.Is<UserId>(m => m.Value == command.UserId)
+                Arg.Is<UserId>(u => u.Value == command.UserId)
             );
     }
 

--- a/tests/Application.Unit.Tests/MonthlyBillings/UpdatePlan/UpdatePlanCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/MonthlyBillings/UpdatePlan/UpdatePlanCommandUtilities.cs
@@ -12,6 +12,7 @@ public static class UpdatePlanCommandUtilities
             "Updated Category",
             258.96m,
             "EUR",
-            99
+            99,
+            Constants.User.Id
         );
 }

--- a/tests/Application.Unit.Tests/TestUtilities/MonthlyBillingUtilities.cs
+++ b/tests/Application.Unit.Tests/TestUtilities/MonthlyBillingUtilities.cs
@@ -14,6 +14,7 @@ public static class MonthlyBillingUtilities
             new(Constants.Constants.MonthlyBilling.Month),
             new(Constants.Constants.MonthlyBilling.Currency),
             Constants.Constants.MonthlyBilling.State,
+            new(Constants.Constants.User.Id),
             plans ?? CreatePlans(),
             incomes ?? CreateIncomes()
         );

--- a/tests/Domain.Unit.Tests/MonthlyBillings/MonthlyBillingTests.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/MonthlyBillingTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection.Metadata;
 using Domain.Exceptions;
 using Domain.MonthlyBillings;
 using Domain.Unit.Tests.MonthlyBillings.TestUtilities;
@@ -48,6 +47,7 @@ public sealed class MonthlyBillingTests
                 new Month(3),
                 new Currency("PLN"),
                 State.Open,
+                Constants.User.Id,
                 null,
                 null
             );
@@ -67,12 +67,33 @@ public sealed class MonthlyBillingTests
                 null,
                 new Currency("PLN"),
                 State.Open,
+                Constants.User.Id,
                 null,
                 null
             );
 
         // Act & Assert
         Assert.Throws<MonthIsNullException>(createMonthlyBilling);
+    }
+
+    [Fact]
+    public void MonthlyBilling_WhenPassedNullUserId_ShouldThrowUserIdIsNullException()
+    {
+        // Arrange
+        var createMonthlyBilling = ()
+            => new MonthlyBilling(
+                new MonthlyBillingId(Guid.NewGuid()),
+                new Year(2007),
+                new Month(3),
+                new Currency("PLN"),
+                State.Open,
+                null,
+                null,
+                null
+            );
+
+        // Act & Assert
+        Assert.Throws<UserIdIsNullException>(createMonthlyBilling);
     }
 
     [Fact]
@@ -86,6 +107,7 @@ public sealed class MonthlyBillingTests
                 new Month(3),
                 null,
                 State.Open,
+                Constants.User.Id,
                 null,
                 null
             );
@@ -103,7 +125,8 @@ public sealed class MonthlyBillingTests
             Constants.MonthlyBilling.Year,
             Constants.MonthlyBilling.Month,
             Constants.MonthlyBilling.Currency,
-            Constants.MonthlyBilling.State
+            Constants.MonthlyBilling.State,
+            Constants.User.Id
         );
 
         // Act
@@ -194,7 +217,8 @@ public sealed class MonthlyBillingTests
             Constants.MonthlyBilling.Year,
             Constants.MonthlyBilling.Month,
             Constants.MonthlyBilling.Currency,
-            Constants.MonthlyBilling.State
+            Constants.MonthlyBilling.State,
+            Constants.User.Id
         );
 
         var addIncomeWithOtherCurrency = () => cut.AddIncome(
@@ -364,7 +388,8 @@ public sealed class MonthlyBillingTests
             Constants.MonthlyBilling.Year,
             Constants.MonthlyBilling.Month,
             Constants.MonthlyBilling.Currency,
-            Constants.MonthlyBilling.State
+            Constants.MonthlyBilling.State,
+            Constants.User.Id
         );
 
         // Act
@@ -400,7 +425,8 @@ public sealed class MonthlyBillingTests
             Constants.MonthlyBilling.Year,
             Constants.MonthlyBilling.Month,
             Constants.MonthlyBilling.Currency,
-            Constants.MonthlyBilling.State
+            Constants.MonthlyBilling.State,
+            Constants.User.Id
         );
 
         // Act
@@ -434,7 +460,8 @@ public sealed class MonthlyBillingTests
             Constants.MonthlyBilling.Year,
             Constants.MonthlyBilling.Month,
             Constants.MonthlyBilling.Currency,
-            Constants.MonthlyBilling.State
+            Constants.MonthlyBilling.State,
+            Constants.User.Id
         );
 
         // Act
@@ -475,6 +502,7 @@ public sealed class MonthlyBillingTests
             Constants.MonthlyBilling.Month,
             Constants.MonthlyBilling.Currency,
             Constants.MonthlyBilling.State,
+            Constants.User.Id,
             null,
             null
         );
@@ -549,7 +577,8 @@ public sealed class MonthlyBillingTests
             Constants.MonthlyBilling.Year,
             Constants.MonthlyBilling.Month,
             Constants.MonthlyBilling.Currency,
-            Constants.MonthlyBilling.State
+            Constants.MonthlyBilling.State,
+            Constants.User.Id
         );
 
         var addPlanWithOtherCurrency = () => cut.AddPlan(
@@ -927,6 +956,7 @@ public sealed class MonthlyBillingTests
             Constants.MonthlyBilling.Month,
             Constants.MonthlyBilling.Currency,
             Constants.MonthlyBilling.State,
+            Constants.User.Id,
             plans: MonthlyBillingUtilities.CreatePlans()
         );
 

--- a/tests/Domain.Unit.Tests/MonthlyBillings/MonthlyBillingTests.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/MonthlyBillingTests.cs
@@ -47,9 +47,7 @@ public sealed class MonthlyBillingTests
                 new Month(3),
                 new Currency("PLN"),
                 State.Open,
-                Constants.User.Id,
-                null,
-                null
+                Constants.User.Id
             );
 
         // Act & Assert
@@ -67,9 +65,7 @@ public sealed class MonthlyBillingTests
                 null,
                 new Currency("PLN"),
                 State.Open,
-                Constants.User.Id,
-                null,
-                null
+                Constants.User.Id
             );
 
         // Act & Assert
@@ -87,8 +83,6 @@ public sealed class MonthlyBillingTests
                 new Month(3),
                 new Currency("PLN"),
                 State.Open,
-                null,
-                null,
                 null
             );
 
@@ -107,9 +101,7 @@ public sealed class MonthlyBillingTests
                 new Month(3),
                 null,
                 State.Open,
-                Constants.User.Id,
-                null,
-                null
+                Constants.User.Id
             );
 
         // Act & Assert
@@ -502,9 +494,7 @@ public sealed class MonthlyBillingTests
             Constants.MonthlyBilling.Month,
             Constants.MonthlyBilling.Currency,
             Constants.MonthlyBilling.State,
-            Constants.User.Id,
-            null,
-            null
+            Constants.User.Id
         );
 
         var plan = new Plan(

--- a/tests/Domain.Unit.Tests/MonthlyBillings/TestUtilities/Constants.User.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/TestUtilities/Constants.User.cs
@@ -1,0 +1,15 @@
+using System;
+using Domain.Users;
+
+namespace Domain.Unit.Tests.MonthlyBillings.TestUtilities;
+
+public static partial class Constants
+{
+    public static class User
+    {
+        public static readonly UserId Id = new(new Guid(0, 0, 0, new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }));
+        public static readonly Email Email = new("smuget-uer@example.com");
+        public static readonly FirstName FirstName = new("Smuget");
+        public const string SecuredPassword = "ABC123";
+    }
+}

--- a/tests/Domain.Unit.Tests/MonthlyBillings/TestUtilities/MonthlyBillingUtilities.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/TestUtilities/MonthlyBillingUtilities.cs
@@ -18,6 +18,7 @@ public static class MonthlyBillingUtilities
             Constants.MonthlyBilling.Month,
             Constants.MonthlyBilling.Currency,
             Constants.MonthlyBilling.State,
+            Constants.User.Id,
             plans ?? CreatePlans(expenses),
             incomes ?? CreateIncomes()
         );

--- a/tests/WebAPI.Unit.Tests/Expenses/ExpensesControllerTests.cs
+++ b/tests/WebAPI.Unit.Tests/Expenses/ExpensesControllerTests.cs
@@ -8,6 +8,7 @@ using Application.MonthlyBillings.UpdateExpense;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using WebAPI.Expenses;
+using WebAPI.Services.Users;
 
 namespace WebAPI.Unit.Tests.Expenses;
 
@@ -18,17 +19,24 @@ public sealed class ExpensesControllerTests
     private readonly Mock<ICommandHandler<AddExpenseCommand>> _mockAddExpenseCommandHandler;
     private readonly Mock<ICommandHandler<UpdateExpenseCommand>> _mockUpdateExpenseCommandHandler;
     private readonly Mock<ICommandHandler<RemoveExpenseCommand>> _mockRemoveExpenseCommandHandler;
+    private readonly Mock<IUserService> _mockUserService;
 
     public ExpensesControllerTests()
     {
         _mockAddExpenseCommandHandler = new Mock<ICommandHandler<AddExpenseCommand>>();
         _mockUpdateExpenseCommandHandler = new Mock<ICommandHandler<UpdateExpenseCommand>>();
         _mockRemoveExpenseCommandHandler = new Mock<ICommandHandler<RemoveExpenseCommand>>();
+        _mockUserService = new Mock<IUserService>();
+
+        _mockUserService
+            .Setup(m => m.UserId)
+            .Returns(Guid.NewGuid());
 
         _cut = new ExpensesController(
             _mockAddExpenseCommandHandler.Object,
             _mockRemoveExpenseCommandHandler.Object,
-            _mockUpdateExpenseCommandHandler.Object
+            _mockUpdateExpenseCommandHandler.Object,
+            _mockUserService.Object
         );
     }
 

--- a/tests/WebAPI.Unit.Tests/Incomes/IncomesControllerTests.cs
+++ b/tests/WebAPI.Unit.Tests/Incomes/IncomesControllerTests.cs
@@ -8,6 +8,7 @@ using Application.MonthlyBillings.UpdateIncome;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using WebAPI.Incomes;
+using WebAPI.Services.Users;
 
 namespace WebAPI.Unit.Tests.Incomes;
 
@@ -18,17 +19,24 @@ public sealed class IncomesControllerTests
     private readonly Mock<ICommandHandler<AddIncomeCommand>> _mockAddIncomeCommandHandler;
     private readonly Mock<ICommandHandler<UpdateIncomeCommand>> _mockUpdateIncomeCommandHandler;
     private readonly Mock<ICommandHandler<RemoveIncomeCommand>> _mockRemoveIncomeCommandHandler;
+    private readonly Mock<IUserService> _mockUserService;
 
     public IncomesControllerTests()
     {
         _mockAddIncomeCommandHandler = new Mock<ICommandHandler<AddIncomeCommand>>();
         _mockUpdateIncomeCommandHandler = new Mock<ICommandHandler<UpdateIncomeCommand>>();
         _mockRemoveIncomeCommandHandler = new Mock<ICommandHandler<RemoveIncomeCommand>>();
+        _mockUserService = new Mock<IUserService>();
+
+        _mockUserService
+            .Setup(m => m.UserId)
+            .Returns(Guid.NewGuid());
 
         _cut = new IncomesController(
             _mockAddIncomeCommandHandler.Object,
             _mockUpdateIncomeCommandHandler.Object,
-            _mockRemoveIncomeCommandHandler.Object
+            _mockRemoveIncomeCommandHandler.Object,
+            _mockUserService.Object
         );
     }
 

--- a/tests/WebAPI.Unit.Tests/MonthlyBillings/MonthlyBillingsControllerTests.cs
+++ b/tests/WebAPI.Unit.Tests/MonthlyBillings/MonthlyBillingsControllerTests.cs
@@ -9,6 +9,8 @@ using Application.MonthlyBillings.GetByYearAndMonth;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using WebAPI.MonthlyBillings;
+using System;
+using WebAPI.Services.Users;
 
 namespace WebAPI.Unit.Tests.MonthlyBillings;
 
@@ -20,6 +22,7 @@ public sealed class MonthlyBillingsControllerTests
     private readonly Mock<IQueryHandler<GetMonthlyBillingByYearAndMonthQuery, MonthlyBillingDTO>> _mockGetMonthlyBillingQueryHandler;
     private readonly Mock<ICommandHandler<CloseMonthlyBillingCommand>> _mockCloseMonthlyBillingCommandHandler;
     private readonly Mock<ICommandHandler<ReopenMonthlyBillingCommand>> _mockReopenMonthlyBillingCommandHandler;
+    private readonly Mock<IUserService> _mockUserService;
 
     public MonthlyBillingsControllerTests()
     {
@@ -27,6 +30,11 @@ public sealed class MonthlyBillingsControllerTests
         _mockGetMonthlyBillingQueryHandler = new Mock<IQueryHandler<GetMonthlyBillingByYearAndMonthQuery, MonthlyBillingDTO>>();
         _mockCloseMonthlyBillingCommandHandler = new Mock<ICommandHandler<CloseMonthlyBillingCommand>>();
         _mockReopenMonthlyBillingCommandHandler = new Mock<ICommandHandler<ReopenMonthlyBillingCommand>>();
+        _mockUserService = new Mock<IUserService>();
+
+        _mockUserService
+            .Setup(m => m.UserId)
+            .Returns(Guid.NewGuid());
 
         _mockGetMonthlyBillingQueryHandler
             .Setup(m => m.HandleAsync(
@@ -42,7 +50,8 @@ public sealed class MonthlyBillingsControllerTests
             _mockOpenMonthlyBillingCommandHandler.Object,
             _mockGetMonthlyBillingQueryHandler.Object,
             _mockCloseMonthlyBillingCommandHandler.Object,
-            _mockReopenMonthlyBillingCommandHandler.Object
+            _mockReopenMonthlyBillingCommandHandler.Object,
+            _mockUserService.Object
         );
     }
 

--- a/tests/WebAPI.Unit.Tests/Plans/PlansControllerTests.cs
+++ b/tests/WebAPI.Unit.Tests/Plans/PlansControllerTests.cs
@@ -8,6 +8,7 @@ using Application.MonthlyBillings.UpdatePlan;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using WebAPI.Plans;
+using WebAPI.Services.Users;
 
 namespace WebAPI.Unit.Tests.Plans;
 
@@ -18,17 +19,24 @@ public sealed class PlansControllerTests
     private readonly Mock<ICommandHandler<AddPlanCommand>> _mockAddPlanCommandHandler;
     private readonly Mock<ICommandHandler<RemovePlanCommand>> _mockRemovePlanCommandHandler;
     private readonly Mock<ICommandHandler<UpdatePlanCommand>> _mockUpdatePlanCommandHandler;
+    private readonly Mock<IUserService> _mockUserService;
 
     public PlansControllerTests()
     {
         _mockAddPlanCommandHandler = new Mock<ICommandHandler<AddPlanCommand>>();
         _mockRemovePlanCommandHandler = new Mock<ICommandHandler<RemovePlanCommand>>();
         _mockUpdatePlanCommandHandler = new Mock<ICommandHandler<UpdatePlanCommand>>();
+        _mockUserService = new Mock<IUserService>();
+
+        _mockUserService
+            .Setup(m => m.UserId)
+            .Returns(Guid.NewGuid());
 
         _cut = new PlansController(
             _mockAddPlanCommandHandler.Object,
             _mockUpdatePlanCommandHandler.Object,
-            _mockRemovePlanCommandHandler.Object
+            _mockRemovePlanCommandHandler.Object,
+            _mockUserService.Object
         );
     }
 


### PR DESCRIPTION
### What?

I'm adding relation between `MonthlyBilling` and `User`. \
User must be authorized in order to make any operation other than `Register()` or `Login()`.

Every command, that needs user identifier, gets the `userId` from the `UserService` which extracts the id from the claims (from HttpContext).

### Why?

From now, user can see and change only his own monthly billings. \
Every user can have his own monthly billing for same month as other users have.

### How?

To `MonthlyBillingsController`, `PlansController`, `IncomesController` and `ExpensesControler` I added `[Authorize]` attribute, which requires from user the valid authorization header (bearer schema). \
If user don't provide valid token he will receive:

```java
401 Unauthorized
```

#### Additional informations
- changed unit tests for all command handlers, that needs userId,
- changed unit tests for all controllers (for plans, incomes, expenses and monthly billings) - they need userService as dependency,
- made manual testing of all available endpoints,
- updated requests with needed header `Authorization`.

Related to #69