### PR TITLE
#68 Feature - Refresh token

### DIFF
--- a/requests/Users/Login.http
+++ b/requests/Users/Login.http
@@ -4,6 +4,6 @@ POST {{host}}/api/users/login
 Content-Type: application/json
 
 {
-    "Email": "test2@user.pl",
+    "Email": "pankunik@pankunik.pl",
     "Password": "Pas$w0rd1"
 }

--- a/requests/Users/Refresh.http
+++ b/requests/Users/Refresh.http
@@ -1,0 +1,7 @@
+# zFxRi8ZRyh4JkBEhLOLN/FdMkPsidl48SAiYRfDD/01ymVfK9Ge2paBYqzLCsj7N1YNA1QmJhrEydzi7tkp/iAuvb+HzTp6gub/PkKkhk4MzpZ5um8FvEANTYuDHyeJZ5tyq6h1o6PymgCI03y/hGkonBLGGg74QyxJmQ3TUzzU=
+@host = https://localhost:7188
+
+POST {{host}}/api/users/refresh
+Content-Type: application/json
+
+"zFxRi8ZRyh4JkBEhLOLN/FdMkPsidl48SAiYRfDD/01ymVfK9Ge2paBYqzLCsj7N1YNA1QmJhrEydzi7tkp/iAuvb+HzTp6gub/PkKkhk4MzpZ5um8FvEANTYuDHyeJZ5tyq6h1o6PymgCI03y/hGkonBLGGg74QyxJmQ3TUzzU="

--- a/requests/Users/Register.http
+++ b/requests/Users/Register.http
@@ -4,7 +4,7 @@ POST {{host}}/api/users/register
 Content-Type: application/json
 
 {
-    "Email": "test2@user.pl",
-    "FirstName": "Test2",
+    "Email": "pankunik@pankunik.pl",
+    "FirstName": "PanKunik",
     "Password": "Pas$w0rd1"
 }

--- a/src/Application/Abstractions/Security/IAuthenticator.cs
+++ b/src/Application/Abstractions/Security/IAuthenticator.cs
@@ -1,6 +1,8 @@
+using Application.Users;
+
 namespace Application.Abstractions.Security;
 
 public interface IAuthenticator
 {
-    string CreateToken(Guid userId);
+    AuthenticationDTO CreateToken(Guid userId);
 }

--- a/src/Application/Abstractions/Security/ITokenStorage.cs
+++ b/src/Application/Abstractions/Security/ITokenStorage.cs
@@ -1,7 +1,9 @@
+using Application.Users;
+
 namespace Application.Abstractions.Security;
 
 public interface ITokenStorage
 {
-    void Store(string token);
-    string Get();
+    void Store(AuthenticationDTO token);
+    AuthenticationDTO Get();
 }

--- a/src/Application/Exceptions/RefreshTokenExpiredException.cs
+++ b/src/Application/Exceptions/RefreshTokenExpiredException.cs
@@ -1,0 +1,9 @@
+using Domain.Exceptions;
+
+namespace Application.Exceptions;
+
+public sealed class RefreshTokenExpiredException : SmugetException
+{
+    public RefreshTokenExpiredException()
+        : base("Refresh token has expired.") { }
+}

--- a/src/Application/Exceptions/RefreshTokenNotFoundException.cs
+++ b/src/Application/Exceptions/RefreshTokenNotFoundException.cs
@@ -1,0 +1,9 @@
+using Domain.Exceptions;
+
+namespace Application.Exceptions;
+
+public sealed class RefreshTokenNotFoundException : SmugetException
+{
+    public RefreshTokenNotFoundException()
+        : base("Refresh token not found.") { }
+}

--- a/src/Application/Exceptions/RefreshTokenUsedException.cs
+++ b/src/Application/Exceptions/RefreshTokenUsedException.cs
@@ -1,0 +1,9 @@
+using Domain.Exceptions;
+
+namespace Application.Exceptions;
+
+public sealed class RefreshTokenUsedException : SmugetException
+{
+    public RefreshTokenUsedException()
+        : base("Refresh token was used before.") { }
+}

--- a/src/Application/Exceptions/UserNotFoundException.cs
+++ b/src/Application/Exceptions/UserNotFoundException.cs
@@ -1,0 +1,9 @@
+using Domain.Exceptions;
+
+namespace Application.Exceptions;
+
+public sealed class UserNotFoundException : SmugetException
+{
+    public UserNotFoundException()
+        : base("User with found id doesn't exist.") { }
+}

--- a/src/Application/Users/AuthenticationDTO.cs
+++ b/src/Application/Users/AuthenticationDTO.cs
@@ -1,0 +1,8 @@
+namespace Application.Users;
+
+public sealed class AuthenticationDTO
+{
+    public string AccessToken { get; set; }
+    public string RefreshToken { get; set; }
+    public DateTime Expires { get; set; }
+}

--- a/src/Application/Users/Login/LoginCommandHandler.cs
+++ b/src/Application/Users/Login/LoginCommandHandler.cs
@@ -49,7 +49,7 @@ public sealed class LoginCommandHandler : ICommandHandler<LoginCommand>
         var refreshToken = new RefreshToken(
             new(Guid.NewGuid()),
             token.RefreshToken,
-            DateTime.Now.AddHours(2),
+            DateTime.UtcNow.AddHours(2),
             false,
             entity.Id
         );

--- a/src/Application/Users/Login/LoginCommandHandler.cs
+++ b/src/Application/Users/Login/LoginCommandHandler.cs
@@ -42,5 +42,6 @@ public sealed class LoginCommandHandler : ICommandHandler<LoginCommand>
 
         var token = _authenticator.CreateToken(entity.Id.Value);
         _tokenStorage.Store(token);
+        // TODO: Save refresh token in database
     }
 }

--- a/src/Application/Users/Refresh/RefreshCommand.cs
+++ b/src/Application/Users/Refresh/RefreshCommand.cs
@@ -1,0 +1,7 @@
+using Application.Abstractions.CQRS;
+
+namespace Application.Users.Refresh;
+
+public sealed record RefreshCommand(
+    string RefreshToken
+) : ICommand;

--- a/src/Application/Users/Refresh/RefreshCommandHandler.cs
+++ b/src/Application/Users/Refresh/RefreshCommandHandler.cs
@@ -1,0 +1,66 @@
+using Application.Abstractions.CQRS;
+using Application.Abstractions.Security;
+using Application.Exceptions;
+using Domain.RefreshTokens;
+using Domain.Repositories;
+
+namespace Application.Users.Refresh;
+
+public sealed class RefreshCommandHandler : ICommandHandler<RefreshCommand>
+{
+    private readonly IRefreshTokensRepository _refreshTokensRepository;
+    private readonly IUsersRepository _usersRepository;
+    private readonly IAuthenticator _authenticator;
+    private readonly ITokenStorage _tokenStorage;
+
+    public RefreshCommandHandler(
+        IRefreshTokensRepository repository,
+        IUsersRepository usersRepository,
+        IAuthenticator authenticator,
+        ITokenStorage tokenStorage
+    )
+    {
+        _refreshTokensRepository = repository;
+        _usersRepository = usersRepository;
+        _authenticator = authenticator;
+        _tokenStorage = tokenStorage;
+    }
+
+    public async Task HandleAsync(
+        RefreshCommand command,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var entity = await _refreshTokensRepository.Get(
+            command.RefreshToken
+        ) ?? throw new RefreshTokenNotFoundException();
+
+        if (entity.WasUsed)
+        {
+            throw new RefreshTokenUsedException();
+        }
+
+        if (entity.Expires < DateTime.UtcNow)
+        {
+            throw new RefreshTokenExpiredException();
+        }
+
+        var userEntity = await _usersRepository.Get(entity.UserId)
+            ?? throw new UserNotFoundException();
+
+        var token = _authenticator.CreateToken(userEntity.Id.Value);
+
+        var refreshToken = new RefreshToken(
+            new(Guid.NewGuid()),
+            token.RefreshToken,
+            DateTime.UtcNow.AddHours(2),
+            false,
+            userEntity.Id
+        );
+        await _refreshTokensRepository.Save(refreshToken);
+
+        entity.Use();
+        await _refreshTokensRepository.Save(entity);
+        _tokenStorage.Store(token);
+    }
+}

--- a/src/Domain/Exceptions/InvalidRefreshTokenIdException.cs
+++ b/src/Domain/Exceptions/InvalidRefreshTokenIdException.cs
@@ -1,0 +1,7 @@
+namespace Domain.Exceptions;
+
+public sealed class InvalidRefreshTokenIdException : SmugetException
+{
+    public InvalidRefreshTokenIdException()
+        : base("Refresh token cannot be empty.") { }
+}

--- a/src/Domain/Exceptions/InvalidTokenException.cs
+++ b/src/Domain/Exceptions/InvalidTokenException.cs
@@ -1,0 +1,7 @@
+namespace Domain.Exceptions;
+
+public sealed class InvalidTokenException : SmugetException
+{
+    public InvalidTokenException()
+        : base("Token cannot be null or empty.") { }
+}

--- a/src/Domain/Exceptions/RefreshTokenIdIsNullException.cs
+++ b/src/Domain/Exceptions/RefreshTokenIdIsNullException.cs
@@ -1,0 +1,7 @@
+namespace Domain.Exceptions;
+
+public sealed class RefreshTokenIdIsNullException : SmugetException
+{
+    public RefreshTokenIdIsNullException()
+        : base("Refresh token id cannot be null.") { }
+}

--- a/src/Domain/RefreshTokens/RefreshToken.cs
+++ b/src/Domain/RefreshTokens/RefreshToken.cs
@@ -1,4 +1,5 @@
 using Domain.Exceptions;
+using Domain.Users;
 
 namespace Domain.RefreshTokens;
 
@@ -8,21 +9,25 @@ public sealed class RefreshToken
     public string Token { get; }
     public DateTime Expires { get; }
     public bool WasUsed { get; }
+    public UserId UserId { get; }
 
     public RefreshToken(
         RefreshTokenId refreshTokenId,
         string token,
         DateTime expires,
-        bool wasUsed
+        bool wasUsed,
+        UserId userId
     )
     {
         ThrowIfRefreshTokenIdIsNull(refreshTokenId);
         ThrowIfTokenIsNullOrWhiteSpace(token);
+        ThrowIfUserIdIsNull(userId);
 
         Id = refreshTokenId;
         Token = token;
         Expires = expires;
         WasUsed = wasUsed;
+        UserId = userId;
     }
 
     private void ThrowIfRefreshTokenIdIsNull(RefreshTokenId refreshTokenId)
@@ -38,6 +43,14 @@ public sealed class RefreshToken
         if (string.IsNullOrWhiteSpace(token))
         {
             throw new InvalidTokenException();
+        }
+    }
+
+    private void ThrowIfUserIdIsNull(UserId userId)
+    {
+        if (userId is null)
+        {
+            throw new UserIdIsNullException();
         }
     }
 }

--- a/src/Domain/RefreshTokens/RefreshToken.cs
+++ b/src/Domain/RefreshTokens/RefreshToken.cs
@@ -1,0 +1,43 @@
+using Domain.Exceptions;
+
+namespace Domain.RefreshTokens;
+
+public sealed class RefreshToken
+{
+    public RefreshTokenId Id { get; }
+    public string Token { get; }
+    public DateTime Expires { get; }
+    public bool WasUsed { get; }
+
+    public RefreshToken(
+        RefreshTokenId refreshTokenId,
+        string token,
+        DateTime expires,
+        bool wasUsed
+    )
+    {
+        ThrowIfRefreshTokenIdIsNull(refreshTokenId);
+        ThrowIfTokenIsNullOrWhiteSpace(token);
+
+        Id = refreshTokenId;
+        Token = token;
+        Expires = expires;
+        WasUsed = wasUsed;
+    }
+
+    private void ThrowIfRefreshTokenIdIsNull(RefreshTokenId refreshTokenId)
+    {
+        if (refreshTokenId is null)
+        {
+            throw new RefreshTokenIdIsNullException();
+        }
+    }
+
+    private void ThrowIfTokenIsNullOrWhiteSpace(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            throw new InvalidTokenException();
+        }
+    }
+}

--- a/src/Domain/RefreshTokens/RefreshToken.cs
+++ b/src/Domain/RefreshTokens/RefreshToken.cs
@@ -8,7 +8,7 @@ public sealed class RefreshToken
     public RefreshTokenId Id { get; }
     public string Token { get; }
     public DateTime Expires { get; }
-    public bool WasUsed { get; }
+    public bool WasUsed { get; private set; }
     public UserId UserId { get; }
 
     public RefreshToken(
@@ -29,6 +29,9 @@ public sealed class RefreshToken
         WasUsed = wasUsed;
         UserId = userId;
     }
+
+    public void Use()
+        => WasUsed = true;
 
     private void ThrowIfRefreshTokenIdIsNull(RefreshTokenId refreshTokenId)
     {

--- a/src/Domain/RefreshTokens/RefreshTokenId.cs
+++ b/src/Domain/RefreshTokens/RefreshTokenId.cs
@@ -1,0 +1,24 @@
+using Domain.Exceptions;
+
+namespace Domain.RefreshTokens;
+
+public sealed record RefreshTokenId
+{
+    public Guid Value { get; }
+
+    public RefreshTokenId(
+        Guid value
+    )
+    {
+        ThrowIfValueIsEqualToEmptyGuid(value);
+        Value = value;
+    }
+
+    private void ThrowIfValueIsEqualToEmptyGuid(Guid value)
+    {
+        if (value == Guid.Empty)
+        {
+            throw new InvalidRefreshTokenIdException();
+        }
+    }
+}

--- a/src/Domain/Repositories/IRefreshTokensRepository.cs
+++ b/src/Domain/Repositories/IRefreshTokensRepository.cs
@@ -1,0 +1,9 @@
+using Domain.RefreshTokens;
+
+namespace Domain.Repositories;
+
+public interface IRefreshTokensRepository
+{
+    Task<RefreshToken?> Get(string token);
+    Task Save(RefreshToken refreshToken);
+}

--- a/src/Domain/Repositories/IUsersRepository.cs
+++ b/src/Domain/Repositories/IUsersRepository.cs
@@ -5,5 +5,6 @@ namespace Domain.Repositories;
 public interface IUsersRepository
 {
     Task<User?> GetByEmail(Email email);
+    Task<User?> Get(UserId userId);
     Task Save(User user);
 }

--- a/src/Infrastructure/Migrations/20231014210750_Adding Refresh tokens entity.Designer.cs
+++ b/src/Infrastructure/Migrations/20231014210750_Adding Refresh tokens entity.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistance;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(SmugetDbContext))]
-    partial class SmugetDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231014210750_Adding Refresh tokens entity")]
+    partial class AddingRefreshtokensentity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20231014210750_Adding Refresh tokens entity.cs
+++ b/src/Infrastructure/Migrations/20231014210750_Adding Refresh tokens entity.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddingRefreshtokensentity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "RefreshTokens",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Token = table.Column<string>(type: "text", nullable: false),
+                    Expires = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    WasUsed = table.Column<bool>(type: "boolean", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RefreshTokens", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RefreshTokens");
+        }
+    }
+}

--- a/src/Infrastructure/Persistance/Configurations/ExpenseEntityConfiguration.cs
+++ b/src/Infrastructure/Persistance/Configurations/ExpenseEntityConfiguration.cs
@@ -1,4 +1,3 @@
-using Domain.MonthlyBillings;
 using Infrastructure.Persistance.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;

--- a/src/Infrastructure/Persistance/Configurations/RefreshTokenEntityConfiguration.cs
+++ b/src/Infrastructure/Persistance/Configurations/RefreshTokenEntityConfiguration.cs
@@ -1,0 +1,37 @@
+using Infrastructure.Persistance.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.Persistance.Configurations;
+
+internal sealed class RefreshTokenEntityConfiguration : IEntityTypeConfiguration<RefreshTokenEntity>
+{
+    public void Configure(EntityTypeBuilder<RefreshTokenEntity> builder)
+    {
+        builder
+            .HasKey(e => e.Id);
+
+        builder
+            .ToTable("RefreshTokens");
+
+        builder
+            .Property(e => e.Id)
+            .IsRequired();
+
+        builder
+            .Property(e => e.Token)
+            .IsRequired();
+
+        builder
+            .Property(e => e.Expires)
+            .IsRequired();
+
+        builder
+            .Property(e => e.WasUsed)
+            .IsRequired();
+
+        builder
+            .Property(e => e.UserId)
+            .IsRequired();
+    }
+}

--- a/src/Infrastructure/Persistance/Entities/Mappings/RefreshTokenMappingExtensions.cs
+++ b/src/Infrastructure/Persistance/Entities/Mappings/RefreshTokenMappingExtensions.cs
@@ -1,0 +1,34 @@
+using Domain.RefreshTokens;
+
+namespace Infrastructure.Persistance.Entities.Mappings;
+
+internal static class RefreshTokenMappingExtensions
+{
+    public static RefreshToken ToDomain(this RefreshTokenEntity entity)
+    {
+        if (entity is null)
+        {
+            return null;
+        }
+
+        return new RefreshToken(
+            new(entity.Id),
+            entity.Token,
+            entity.Expires,
+            entity.WasUsed,
+            new(entity.UserId)
+        );
+    }
+
+    public static RefreshTokenEntity ToEntity(this RefreshToken domain)
+    {
+        return new RefreshTokenEntity()
+        {
+            Id = domain.Id.Value,
+            Token = domain.Token,
+            Expires = domain.Expires,
+            WasUsed = domain.WasUsed,
+            UserId = domain.UserId.Value
+        };
+    }
+}

--- a/src/Infrastructure/Persistance/Entities/RefreshTokenEntity.cs
+++ b/src/Infrastructure/Persistance/Entities/RefreshTokenEntity.cs
@@ -1,0 +1,10 @@
+namespace Infrastructure.Persistance.Entities;
+
+internal sealed class RefreshTokenEntity
+{
+    public Guid Id { get; set; }
+    public string Token { get; set; }
+    public DateTime Expires { get; set; }
+    public bool WasUsed { get; set; }
+    public Guid UserId { get; set; }
+}

--- a/src/Infrastructure/Persistance/Repositories/Extensions.cs
+++ b/src/Infrastructure/Persistance/Repositories/Extensions.cs
@@ -9,6 +9,7 @@ internal static class RepositoryExtensions
     {
         services.AddTransient<IMonthlyBillingsRepository, MonthlyBillingsRepository>();
         services.AddTransient<IUsersRepository, UsersRepository>();
+        services.AddTransient<IRefreshTokensRepository, RefreshTokensRepository>();
 
         return services;
     }

--- a/src/Infrastructure/Persistance/Repositories/RefreshTokensRepository.cs
+++ b/src/Infrastructure/Persistance/Repositories/RefreshTokensRepository.cs
@@ -1,50 +1,38 @@
+using Domain.RefreshTokens;
 using Domain.Repositories;
-using Domain.Users;
 using Infrastructure.Persistance.Entities.Mappings;
 using Microsoft.EntityFrameworkCore;
 
 namespace Infrastructure.Persistance.Repositories;
 
-internal sealed class UsersRepository : IUsersRepository
+internal sealed class RefreshTokensRepository : IRefreshTokensRepository
 {
     private readonly SmugetDbContext _dbContext;
 
-    public UsersRepository(SmugetDbContext dbContext)
+    public RefreshTokensRepository(SmugetDbContext dbContext)
     {
         _dbContext = dbContext;
     }
 
-    public async Task<User?> GetByEmail(Email email)
+    public async Task<RefreshToken?> Get(string token)
     {
-        var entity = await _dbContext.Users
+        var entity = await _dbContext.RefreshTokens
             .AsNoTracking()
             .FirstOrDefaultAsync(
-                u => u.Email == email.Value
+                u => u.Token == token
             );
 
         return entity?
             .ToDomain();
     }
 
-    public async Task<User?> Get(UserId userId)
+    public async Task Save(RefreshToken refreshToken)
     {
-        var entiy = await _dbContext.Users
+        var newEntity = refreshToken.ToEntity();
+        var existingEntity = await _dbContext.RefreshTokens
             .AsNoTracking()
             .FirstOrDefaultAsync(
-                u => u.Id == userId.Value
-            );
-
-        return entiy?
-            .ToDomain();
-    }
-
-    public async Task Save(User user)
-    {
-        var newEntity = user.ToEntity();
-        var existingEntity = await _dbContext.Users
-            .AsNoTracking()
-            .FirstOrDefaultAsync(
-                u => u.Id == user.Id.Value
+                u => u.Id == refreshToken.Id.Value
             );
 
         if (existingEntity is null)

--- a/src/Infrastructure/Persistance/SmugetDbContext.cs
+++ b/src/Infrastructure/Persistance/SmugetDbContext.cs
@@ -10,6 +10,7 @@ internal sealed class SmugetDbContext : DbContext
 
     public DbSet<MonthlyBillingEntity> MonthlyBillings { get; set; }
     public DbSet<UserEntity> Users { get; set; }
+    public DbSet<RefreshTokenEntity> RefreshTokens { get; set; }
 
     protected override void OnModelCreating(ModelBuilder builder)
     {

--- a/src/Infrastructure/Security/Authenticator.cs
+++ b/src/Infrastructure/Security/Authenticator.cs
@@ -1,7 +1,9 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using System.Security.Cryptography;
 using System.Text;
 using Application.Abstractions.Security;
+using Application.Users;
 using Infrastructure.Authentication;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
@@ -34,7 +36,7 @@ internal sealed class Authenticator : IAuthenticator
         );
     }
 
-    public string CreateToken(Guid userId)
+    public AuthenticationDTO CreateToken(Guid userId)
     {
         var claims = new List<Claim>()
         {
@@ -56,6 +58,11 @@ internal sealed class Authenticator : IAuthenticator
         var token = new JwtSecurityTokenHandler()
             .WriteToken(jwt);
 
-        return token;
+        return new AuthenticationDTO()
+        {
+            AccessToken = token,
+            RefreshToken = Convert.ToBase64String(RandomNumberGenerator.GetBytes(128)),
+            Expires = expires
+        };
     }
 }

--- a/src/Infrastructure/Security/HttpContextTokenStorage.cs
+++ b/src/Infrastructure/Security/HttpContextTokenStorage.cs
@@ -1,4 +1,5 @@
 using Application.Abstractions.Security;
+using Application.Users;
 using Microsoft.AspNetCore.Http;
 
 internal sealed class HttpContextTokenStorage : ITokenStorage
@@ -11,14 +12,19 @@ internal sealed class HttpContextTokenStorage : ITokenStorage
         _httpContextAccessor = httpContextAccessor;
     }
 
-    public void Store(string token)
+    public void Store(AuthenticationDTO token)
         => _httpContextAccessor.HttpContext?.Items.TryAdd(
                 TokenKey,
                 token
             );
 
-    public string Get()
-        => _httpContextAccessor.HttpContext.Items.TryGetValue(
-                TokenKey,
-                out var jwt) ? (string)jwt : null;
+    public AuthenticationDTO Get()
+    {
+        object? token = null;
+        _httpContextAccessor.HttpContext?.Items.TryGetValue(
+            TokenKey,
+            out token
+        );
+        return token as AuthenticationDTO;
+    }
 }

--- a/tests/Application.Unit.Tests/TestUtilities/Constants/Constants.RefreshToken.cs
+++ b/tests/Application.Unit.Tests/TestUtilities/Constants/Constants.RefreshToken.cs
@@ -1,0 +1,12 @@
+namespace Application.Unit.Tests.TestUtilities.Constants;
+
+public static partial class Constants
+{
+    public static class RefreshToken
+    {
+        public static readonly Guid Id = new Guid(0, 0, 0, new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 });
+        public const string Token = "3FAn5gJc/RyQ6zPwH/+mFA==";
+        public static readonly DateTime Expires = DateTime.Now.AddDays(1);
+        public const bool WasUsed = false;
+    }
+}

--- a/tests/Application.Unit.Tests/TestUtilities/Constants/Constants.User.cs
+++ b/tests/Application.Unit.Tests/TestUtilities/Constants/Constants.User.cs
@@ -10,6 +10,5 @@ public static partial class Constants
         public const string Password = "P@$sw0rd1";
         public const string SecuredPassword = "4a6fafec30def6bfe3ac4e8a538810ff";
         public const string AccessToken = "WTo/eWQn2xu/imQaWx1c/A==";
-        public const string RefreshToken = "3FAn5gJc/RyQ6zPwH/+mFA==";
     }
 }

--- a/tests/Application.Unit.Tests/TestUtilities/Constants/Constants.User.cs
+++ b/tests/Application.Unit.Tests/TestUtilities/Constants/Constants.User.cs
@@ -9,5 +9,7 @@ public static partial class Constants
         public const string FirstName = "Regular";
         public const string Password = "P@$sw0rd1";
         public const string SecuredPassword = "4a6fafec30def6bfe3ac4e8a538810ff";
+        public const string AccessToken = "WTo/eWQn2xu/imQaWx1c/A==";
+        public const string RefreshToken = "3FAn5gJc/RyQ6zPwH/+mFA==";
     }
 }

--- a/tests/Application.Unit.Tests/TestUtilities/RefreshTokensUtilities.cs
+++ b/tests/Application.Unit.Tests/TestUtilities/RefreshTokensUtilities.cs
@@ -1,0 +1,33 @@
+using Domain.RefreshTokens;
+
+namespace Application.Unit.Tests.TestUtilities;
+
+public static class RefreshTokensUtilities
+{
+    public static RefreshToken CreateRefreshToken()
+        => new(
+            new(Constants.Constants.RefreshToken.Id),
+            Constants.Constants.RefreshToken.Token,
+            Constants.Constants.RefreshToken.Expires,
+            Constants.Constants.RefreshToken.WasUsed,
+            new(Constants.Constants.User.Id)
+        );
+
+    public static RefreshToken CreateExpiredRefreshToken()
+        => new(
+            new(Constants.Constants.RefreshToken.Id),
+            Constants.Constants.RefreshToken.Token,
+            DateTime.Now.AddDays(-1),
+            Constants.Constants.RefreshToken.WasUsed,
+            new(Constants.Constants.User.Id)
+        );
+
+    public static RefreshToken CreateUsedRefreshToken()
+        => new(
+            new(Constants.Constants.RefreshToken.Id),
+            Constants.Constants.RefreshToken.Token,
+            Constants.Constants.RefreshToken.Expires,
+            true,
+            new(Constants.Constants.User.Id)
+        );
+}

--- a/tests/Application.Unit.Tests/TestUtilities/RefreshTokensUtilities.cs
+++ b/tests/Application.Unit.Tests/TestUtilities/RefreshTokensUtilities.cs
@@ -36,7 +36,7 @@ public static class RefreshTokensUtilities
             new(Constants.Constants.RefreshToken.Id),
             Constants.Constants.RefreshToken.Token,
             Constants.Constants.RefreshToken.Expires,
-            true,
+            Constants.Constants.RefreshToken.WasUsed,
             new(new Guid(21, 12, 5, new byte[] { 0, 9, 1, 3, 2, 5, 32, 22 }))
         );
 }

--- a/tests/Application.Unit.Tests/TestUtilities/RefreshTokensUtilities.cs
+++ b/tests/Application.Unit.Tests/TestUtilities/RefreshTokensUtilities.cs
@@ -30,4 +30,13 @@ public static class RefreshTokensUtilities
             true,
             new(Constants.Constants.User.Id)
         );
+
+    public static RefreshToken CreateForeignRefreshToken()
+        => new(
+            new(Constants.Constants.RefreshToken.Id),
+            Constants.Constants.RefreshToken.Token,
+            Constants.Constants.RefreshToken.Expires,
+            true,
+            new(new Guid(21, 12, 5, new byte[] { 0, 9, 1, 3, 2, 5, 32, 22 }))
+        );
 }

--- a/tests/Application.Unit.Tests/Users/Login/LoginCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/Users/Login/LoginCommandHandlerTests.cs
@@ -45,7 +45,7 @@ public sealed class LoginCommandHandlerTests
                 new AuthenticationDTO()
                 {
                     AccessToken = Constants.User.AccessToken,
-                    RefreshToken = Constants.User.RefreshToken
+                    RefreshToken = Constants.RefreshToken.Token
                 }
             );
 
@@ -179,7 +179,7 @@ public sealed class LoginCommandHandlerTests
             .Save(
                 Arg.Is<RefreshToken>(
                     r => r.UserId.Value == Constants.User.Id
-                      && r.Token == Constants.User.RefreshToken
+                      && r.Token == Constants.RefreshToken.Token
                       && r.WasUsed == false
                 )
             );
@@ -203,7 +203,7 @@ public sealed class LoginCommandHandlerTests
             .Store(
                 Arg.Is<AuthenticationDTO>(
                     a => a.AccessToken == Constants.User.AccessToken
-                      && a.RefreshToken == Constants.User.RefreshToken
+                      && a.RefreshToken == Constants.RefreshToken.Token
                 )
             );
     }

--- a/tests/Application.Unit.Tests/Users/Refresh/RefreshCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/Users/Refresh/RefreshCommandHandlerTests.cs
@@ -23,7 +23,7 @@ public sealed class RefreshCommandHandlerTests
         _refreshTokensRepository = Substitute.For<IRefreshTokensRepository>();
 
         _refreshTokensRepository
-            .Get(Constants.User.RefreshToken)
+            .Get(Constants.RefreshToken.Token)
             .Returns(RefreshTokensUtilities.CreateRefreshToken());
 
         _refreshTokensRepository
@@ -52,7 +52,7 @@ public sealed class RefreshCommandHandlerTests
                 new AuthenticationDTO()
                 {
                     AccessToken = Constants.User.AccessToken,
-                    RefreshToken = Constants.User.RefreshToken
+                    RefreshToken = Constants.RefreshToken.Token
                 }
             );
 
@@ -81,7 +81,7 @@ public sealed class RefreshCommandHandlerTests
         // Assert
         await _refreshTokensRepository
             .Received(1)
-            .Get(Arg.Is<string>(a => a == Constants.User.RefreshToken));
+            .Get(Arg.Is<string>(a => a == Constants.RefreshToken.Token));
     }
 
     [Fact]
@@ -190,7 +190,7 @@ public sealed class RefreshCommandHandlerTests
             .Save(
                 Arg.Is<RefreshToken>(
                     r => r.UserId.Value == Constants.User.Id
-                      && r.Token == Constants.User.RefreshToken
+                      && r.Token == Constants.RefreshToken.Token
                       && r.WasUsed == false
                 )
             );
@@ -214,7 +214,7 @@ public sealed class RefreshCommandHandlerTests
             .Store(
                 Arg.Is<AuthenticationDTO>(
                     a => a.AccessToken == Constants.User.AccessToken
-                      && a.RefreshToken == Constants.User.RefreshToken
+                      && a.RefreshToken == Constants.RefreshToken.Token
                 )
             );
     }

--- a/tests/Application.Unit.Tests/Users/Refresh/RefreshCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/Users/Refresh/RefreshCommandHandlerTests.cs
@@ -1,0 +1,221 @@
+using Application.Abstractions.Security;
+using Application.Exceptions;
+using Application.Unit.Tests.TestUtilities;
+using Application.Unit.Tests.TestUtilities.Constants;
+using Application.Users;
+using Application.Users.Refresh;
+using Domain.RefreshTokens;
+using Domain.Repositories;
+
+namespace Application.Unit.Tests.Users.Refresh;
+
+public sealed class RefreshCommandHandlerTests
+{
+    private readonly IRefreshTokensRepository _refreshTokensRepository;
+    private readonly IUsersRepository _usersRepository;
+    private readonly IAuthenticator _authenticator;
+    private readonly ITokenStorage _tokenStorage;
+
+    private readonly RefreshCommandHandler _cut;
+
+    public RefreshCommandHandlerTests()
+    {
+        _refreshTokensRepository = Substitute.For<IRefreshTokensRepository>();
+
+        _refreshTokensRepository
+            .Get(Constants.User.RefreshToken)
+            .Returns(RefreshTokensUtilities.CreateRefreshToken());
+
+        _refreshTokensRepository
+            .Get("expired-token")
+            .Returns(RefreshTokensUtilities.CreateExpiredRefreshToken());
+
+        _refreshTokensRepository
+            .Get("used-token")
+            .Returns(RefreshTokensUtilities.CreateUsedRefreshToken());
+
+        _refreshTokensRepository
+            .Get("token-for-other-user")
+            .Returns(RefreshTokensUtilities.CreateForeignRefreshToken());
+
+        _usersRepository = Substitute.For<IUsersRepository>();
+
+        _usersRepository
+            .Get(new(Constants.User.Id))
+            .Returns(UsersUtilities.CreateUser());
+
+        _authenticator = Substitute.For<IAuthenticator>();
+
+        _authenticator
+            .CreateToken(Constants.User.Id)
+            .Returns(
+                new AuthenticationDTO()
+                {
+                    AccessToken = Constants.User.AccessToken,
+                    RefreshToken = Constants.User.RefreshToken
+                }
+            );
+
+        _tokenStorage = Substitute.For<ITokenStorage>();
+
+        _cut = new RefreshCommandHandler(
+            _refreshTokensRepository,
+            _usersRepository,
+            _authenticator,
+            _tokenStorage
+        );
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenInvoked_ShouldCallGetOnRepositoryOnce()
+    {
+        // Arrange
+        var command = RefreshCommandUtilities.CreateCommand();
+
+        // Act
+        await _cut.HandleAsync(
+            command,
+            default
+        );
+
+        // Assert
+        await _refreshTokensRepository
+            .Received(1)
+            .Get(Arg.Is<string>(a => a == Constants.User.RefreshToken));
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenTokenDoesntExist_ShouldThrowRefreshTokenNotFoundException()
+    {
+        // Arrange
+        var command = new RefreshCommand(
+            "abc123"
+        );
+
+        var commandAction = () => _cut.HandleAsync(
+            command,
+            default
+        );
+
+        // Act & Assert
+        await Assert.ThrowsAsync<RefreshTokenNotFoundException>(commandAction);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenTokenWasUsedBefore_ShouldThrowRefreshTokenUsedException()
+    {
+        // Arrange
+        var command = new RefreshCommand(
+            "used-token"
+        );
+
+        var commandAction = () => _cut.HandleAsync(
+            command,
+            default
+        );
+
+        // Act & Assert
+        await Assert.ThrowsAsync<RefreshTokenUsedException>(commandAction);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenTokenHasExpired_ShouldThrowRefreshTokenExpiredException()
+    {
+        // Arrange
+        var command = new RefreshCommand(
+            "expired-token"
+        );
+
+        var commandAction = () => _cut.HandleAsync(
+            command,
+            default
+        );
+
+        // Act & Assert
+        await Assert.ThrowsAsync<RefreshTokenExpiredException>(commandAction);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenUserDOesntExist_ShouldThrowUserNotFoundException()
+    {
+        // Arrange
+        var command = new RefreshCommand(
+            "token-for-other-user"
+        );
+
+        var commandAction = () => _cut.HandleAsync(
+            command,
+            default
+        );
+
+        // Act & Assert
+        await Assert.ThrowsAsync<UserNotFoundException>(commandAction);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenTokenAndUserWasFound_ShouldCallCreateTokenOnAuthenticatorOnce()
+    {
+        // Arrange
+        var login = RefreshCommandUtilities.CreateCommand();
+
+        // Act
+        await _cut.HandleAsync(
+            login,
+            default
+        );
+
+        // Assert
+        _authenticator
+            .Received(1)
+            .CreateToken(
+                Arg.Is(Constants.User.Id)
+            );
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenTokenCreatedSuccessfully_ShouldCallSaveOnRefreshTokenRepositoryOnce()
+    {
+        // Arrange
+        var login = RefreshCommandUtilities.CreateCommand();
+
+        // Act
+        await _cut.HandleAsync(
+            login,
+            default
+        );
+
+        // Assert
+        await _refreshTokensRepository
+            .Received(1)
+            .Save(
+                Arg.Is<RefreshToken>(
+                    r => r.UserId.Value == Constants.User.Id
+                      && r.Token == Constants.User.RefreshToken
+                      && r.WasUsed == false
+                )
+            );
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenTokenCreatedSuccessfully_ShouldCallStoreOnTokenStorageOnce()
+    {
+        // Arrange
+        var login = RefreshCommandUtilities.CreateCommand();
+
+        // Act
+        await _cut.HandleAsync(
+            login,
+            default
+        );
+
+        // Assert
+        _tokenStorage
+            .Received(1)
+            .Store(
+                Arg.Is<AuthenticationDTO>(
+                    a => a.AccessToken == Constants.User.AccessToken
+                      && a.RefreshToken == Constants.User.RefreshToken
+                )
+            );
+    }
+}

--- a/tests/Application.Unit.Tests/Users/Refresh/RefreshCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/Users/Refresh/RefreshCommandUtilities.cs
@@ -1,0 +1,12 @@
+using Application.Unit.Tests.TestUtilities.Constants;
+using Application.Users.Refresh;
+
+namespace Application.Unit.Tests.Users.Refresh;
+
+public static class RefreshCommandUtilities
+{
+    public static RefreshCommand CreateCommand()
+        => new(
+            Constants.User.RefreshToken
+        );
+}

--- a/tests/Application.Unit.Tests/Users/Refresh/RefreshCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/Users/Refresh/RefreshCommandUtilities.cs
@@ -7,6 +7,6 @@ public static class RefreshCommandUtilities
 {
     public static RefreshCommand CreateCommand()
         => new(
-            Constants.User.RefreshToken
+            Constants.RefreshToken.Token
         );
 }

--- a/tests/Domain.Unit.Tests/MonthlyBillings/TestUtilities/Constants.RefreshToken.cs
+++ b/tests/Domain.Unit.Tests/MonthlyBillings/TestUtilities/Constants.RefreshToken.cs
@@ -1,0 +1,15 @@
+using System;
+using Domain.RefreshTokens;
+
+namespace Domain.Unit.Tests.MonthlyBillings.TestUtilities;
+
+public static partial class Constants
+{
+    public static class RefreshToken
+    {
+        public static readonly RefreshTokenId Id = new(new Guid(0, 0, 0, new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }));
+        public const string Token = "3FAn5gJc/RyQ6zPwH/+mFA==";
+        public static readonly DateTime Expires = DateTime.Now.AddDays(1);
+        public const bool WasUsed = false;
+    }
+}

--- a/tests/Domain.Unit.Tests/RefreshTokens/RefreshTokenIdTests.cs
+++ b/tests/Domain.Unit.Tests/RefreshTokens/RefreshTokenIdTests.cs
@@ -1,0 +1,43 @@
+using System;
+using Domain.Exceptions;
+using Domain.RefreshTokens;
+
+namespace Domain.Unit.Tests.RefreshTokens;
+
+public sealed class RefreshTokenIdTests
+{
+    [Fact]
+    public void RefreshTokenId_WhenCalled_ShouldReturnExpectedObject()
+    {
+        // Arrange
+        var guid = Guid.NewGuid();
+
+        // Act
+        var result = new RefreshTokenId(
+            guid
+        );
+
+        // Assert
+        result
+            .Should()
+            .NotBeNull();
+
+        result
+            .Should()
+            .Match<RefreshTokenId>(
+                r => r.Value == guid
+            );
+    }
+
+    [Fact]
+    public void RefreshToken_WhenPassedValueEqualToEmptyGuid_ShouldThrowInvalidRefreshTokenIdException()
+    {
+        // Arrange
+        var cut = () => new RefreshTokenId(
+            Guid.Empty
+        );
+
+        // Act & Assert
+        Assert.Throws<InvalidRefreshTokenIdException>(cut);
+    }
+}

--- a/tests/Domain.Unit.Tests/RefreshTokens/RefreshTokenTests.cs
+++ b/tests/Domain.Unit.Tests/RefreshTokens/RefreshTokenTests.cs
@@ -14,7 +14,8 @@ public sealed class RefreshTokenTests
             Constants.RefreshToken.Id,
             Constants.RefreshToken.Token,
             Constants.RefreshToken.Expires,
-            Constants.RefreshToken.WasUsed
+            Constants.RefreshToken.WasUsed,
+            Constants.User.Id
         );
 
         // Assert
@@ -37,7 +38,8 @@ public sealed class RefreshTokenTests
             null,
             Constants.RefreshToken.Token,
             Constants.RefreshToken.Expires,
-            Constants.RefreshToken.WasUsed
+            Constants.RefreshToken.WasUsed,
+            Constants.User.Id
         );
 
         // Act & Assert
@@ -55,10 +57,27 @@ public sealed class RefreshTokenTests
             Constants.RefreshToken.Id,
             value,
             Constants.RefreshToken.Expires,
-            Constants.RefreshToken.WasUsed
+            Constants.RefreshToken.WasUsed,
+            Constants.User.Id
         );
 
         // Act & Assert
         Assert.Throws<InvalidTokenException>(cut);
+    }
+
+    [Fact]
+    public void RefreshToken_WhenPassedNullUserId_ShouldThrowUserIdIsNullException()
+    {
+        // Arrange
+        var cut = () => new RefreshToken(
+            Constants.RefreshToken.Id,
+            Constants.RefreshToken.Token,
+            Constants.RefreshToken.Expires,
+            Constants.RefreshToken.WasUsed,
+            null
+        );
+
+        // Act & Assert
+        Assert.Throws<UserIdIsNullException>(cut);
     }
 }

--- a/tests/Domain.Unit.Tests/RefreshTokens/RefreshTokenTests.cs
+++ b/tests/Domain.Unit.Tests/RefreshTokens/RefreshTokenTests.cs
@@ -1,0 +1,64 @@
+using Domain.Exceptions;
+using Domain.RefreshTokens;
+using Domain.Unit.Tests.MonthlyBillings.TestUtilities;
+
+namespace Domain.Unit.Tests.RefreshTokens;
+
+public sealed class RefreshTokenTests
+{
+    [Fact]
+    public void RefreshToken_WhenCalled_ShouldReturnExpectedObject()
+    {
+        // Act
+        var cut = new RefreshToken(
+            Constants.RefreshToken.Id,
+            Constants.RefreshToken.Token,
+            Constants.RefreshToken.Expires,
+            Constants.RefreshToken.WasUsed
+        );
+
+        // Assert
+        cut
+            .Should()
+            .NotBeNull();
+
+        cut
+            .Should()
+            .Match<RefreshToken>(
+                r => r.Id == Constants.RefreshToken.Id
+            );
+    }
+
+    [Fact]
+    public void RefreshToken_WhenPassedNullRefreshTokenId_ShouldThrowRefreshTokenIdIsNullException()
+    {
+        // Arrange
+        var cut = () => new RefreshToken(
+            null,
+            Constants.RefreshToken.Token,
+            Constants.RefreshToken.Expires,
+            Constants.RefreshToken.WasUsed
+        );
+
+        // Act & Assert
+        Assert.Throws<RefreshTokenIdIsNullException>(cut);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public void RefreshToken_WhenPassedNullOrWhiteSpaceToken_ShouldThrowInvalidTokenException(string value)
+    {
+        // Arrange
+        var cut = () => new RefreshToken(
+            Constants.RefreshToken.Id,
+            value,
+            Constants.RefreshToken.Expires,
+            Constants.RefreshToken.WasUsed
+        );
+
+        // Act & Assert
+        Assert.Throws<InvalidTokenException>(cut);
+    }
+}

--- a/tests/WebAPI.Unit.Tests/Users/UsersControllerTests.cs
+++ b/tests/WebAPI.Unit.Tests/Users/UsersControllerTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Application.Abstractions.CQRS;
 using Application.Abstractions.Security;
 using Application.Users.Login;
+using Application.Users.Refresh;
 using Application.Users.Register;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
@@ -16,17 +17,20 @@ public sealed class UsersControllerTests
 
     private readonly Mock<ICommandHandler<RegisterCommand>> _mockRegister;
     private readonly Mock<ICommandHandler<LoginCommand>> _mockLogin;
+    private readonly Mock<ICommandHandler<RefreshCommand>> _mockRefresh;
     private readonly Mock<ITokenStorage> _mockTokenStorage;
 
     public UsersControllerTests()
     {
         _mockRegister = new Mock<ICommandHandler<RegisterCommand>>();
         _mockLogin = new Mock<ICommandHandler<LoginCommand>>();
+        _mockRefresh = new Mock<ICommandHandler<RefreshCommand>>();
         _mockTokenStorage = new Mock<ITokenStorage>();
 
         _cut = new UsersController(
             _mockRegister.Object,
             _mockLogin.Object,
+            _mockRefresh.Object,
             _mockTokenStorage.Object
         );
     }
@@ -218,6 +222,53 @@ public sealed class UsersControllerTests
                     ),
                     It.IsAny<CancellationToken>()
                 )
+            );
+    }
+
+    [Fact]
+    public async Task Refresh_OnSuccess_ShouldReturnOkObjectResult()
+    {
+        // Act
+        var result = await _cut.Refresh("EpN8h+GhVmOIPiY3Qdj73NEXDkUifMLTxYBB3DWArjt29VbRsu/4XaQQM/AWgx/aa6B3e1UMVHVpWgNRNQCYPBOVhm2jQMX3TSns8jgt/CoSOfEQNTsF9eVifoKSAVUU9hevr07Yv6SdTqHReoIOPsoNlfqgrwDCmZDOwjw4ABo");
+
+        // Assert
+        result
+            .Should()
+            .NotBeNull();
+
+        result
+            .Should()
+            .BeOfType<OkObjectResult>();
+    }
+
+    [Fact]
+    public async Task Refresh_OnSuccess_ShouldReturn200OkStatusCode()
+    {
+        // Act
+        var result = (OkObjectResult)await _cut.Refresh("EpN8h+GhVmOIPiY3Qdj73NEXDkUifMLTxYBB3DWArjt29VbRsu/4XaQQM/AWgx/aa6B3e1UMVHVpWgNRNQCYPBOVhm2jQMX3TSns8jgt/CoSOfEQNTsF9eVifoKSAVUU9hevr07Yv6SdTqHReoIOPsoNlfqgrwDCmZDOwjw4ABo");
+
+        // Assert
+        result.StatusCode
+            .Should()
+            .Be(200);
+    }
+
+    [Fact]
+    public async Task Refresh_WhenInvokedWithParameters_ShouldCallRefreshCommandHandlerWithParametersOnce()
+    {
+        // Act
+        await _cut.Refresh("EpN8h+GhVmOIPiY3Qdj73NEXDkUifMLTxYBB3DWArjt29VbRsu/4XaQQM/AWgx/aa6B3e1UMVHVpWgNRNQCYPBOVhm2jQMX3TSns8jgt/CoSOfEQNTsF9eVifoKSAVUU9hevr07Yv6SdTqHReoIOPsoNlfqgrwDCmZDOwjw4ABo");
+
+        // Assert
+        _mockRefresh
+            .Verify(
+                l => l.HandleAsync(
+                    It.Is<RefreshCommand>(
+                        c => c.RefreshToken == "EpN8h+GhVmOIPiY3Qdj73NEXDkUifMLTxYBB3DWArjt29VbRsu/4XaQQM/AWgx/aa6B3e1UMVHVpWgNRNQCYPBOVhm2jQMX3TSns8jgt/CoSOfEQNTsF9eVifoKSAVUU9hevr07Yv6SdTqHReoIOPsoNlfqgrwDCmZDOwjw4ABo"
+                    ),
+                    It.IsAny<CancellationToken>()
+                ),
+                Times.Once
             );
     }
 }


### PR DESCRIPTION
### What?

I'm adding ability to refresh access token using refresh tokens. \
User can pass his refresh token under the route:

```java
[POST] /api/users/refresh
```

as a string with `Content-Type` set to `application/json`. If refresh token is valid for the user, didn't expire and wasn't used before user will receive new access token with a fresh refresh token.

### Why?

With refresh tokens user can re-authenticate them in application without passing their credentials again.

Related to #68 