### PR TITLE
#89 Feature - Allowing to remove transactions

### DIFF
--- a/src/Application/PiggyBanks/RemoveTransaction/RemoveTransactionCommand.cs
+++ b/src/Application/PiggyBanks/RemoveTransaction/RemoveTransactionCommand.cs
@@ -1,0 +1,9 @@
+using Application.Abstractions.CQRS;
+
+namespace Application.PiggyBanks.RemoveTransaction;
+
+public sealed record RemoveTransactionCommand(
+    Guid PiggyBankId,
+    Guid TransactionId,
+    Guid UserId
+) : ICommand;

--- a/src/Application/PiggyBanks/RemoveTransaction/RemoveTransactionCommandHandler.cs
+++ b/src/Application/PiggyBanks/RemoveTransaction/RemoveTransactionCommandHandler.cs
@@ -1,0 +1,42 @@
+using Application.Abstractions.CQRS;
+using Application.Exceptions;
+using Domain.PiggyBanks;
+using Domain.Repositories;
+using Domain.Users;
+
+namespace Application.PiggyBanks.RemoveTransaction;
+
+public sealed class RemoveTransactionCommandHandler
+    : ICommandHandler<RemoveTransactionCommand>
+{
+    private readonly IPiggyBanksRepository _repository;
+
+    public RemoveTransactionCommandHandler(IPiggyBanksRepository repository)
+    {
+        _repository = repository
+            ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public async Task HandleAsync(
+        RemoveTransactionCommand command,
+        CancellationToken cancellationToken = default
+    )
+    {
+        PiggyBankId piggyBankId = new(command.PiggyBankId);
+        TransactionId transactionId = new(command.TransactionId);
+        UserId userId = new(command.UserId);
+
+        var entity = await _repository.GetById(
+            piggyBankId,
+            userId
+        );
+
+        if (entity is null)
+        {
+            throw new PiggyBankNotFoundException(piggyBankId);
+        }
+
+        entity.RemoveTransaction(transactionId);
+        await _repository.Save(entity);
+    }
+}

--- a/src/Domain/Exceptions/TransactionNotFoundException.cs
+++ b/src/Domain/Exceptions/TransactionNotFoundException.cs
@@ -1,0 +1,14 @@
+using Domain.PiggyBanks;
+
+namespace Domain.Exceptions;
+
+public sealed class TransactionNotFoundException
+    : NotFoundException
+{
+    public TransactionNotFoundException(TransactionId transactionId)
+        : base(
+            nameof(Transaction),
+            nameof(Transaction.Id),
+            transactionId.Value.ToString()    
+        ) { }
+}

--- a/src/Domain/Piggybanks/Piggybank.cs
+++ b/src/Domain/Piggybanks/Piggybank.cs
@@ -97,4 +97,16 @@ public sealed class PiggyBank
             throw new TransactionAlreadyExistsException(transaction.Id);
         }
     }
+
+    public void RemoveTransaction(TransactionId transactionId)
+    {
+        var transactionToRemove = _transactions.Find(t => t.Id == transactionId);
+
+        if (transactionToRemove is null)
+        {
+            throw new TransactionNotFoundException(transactionId);
+        }
+
+        _transactions.Remove(transactionToRemove);
+    }
 }

--- a/tests/Application.Unit.Tests/PiggyBanks/RemoveTransaction/RemoveTransactionCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/PiggyBanks/RemoveTransaction/RemoveTransactionCommandHandlerTests.cs
@@ -1,0 +1,111 @@
+using System.Reflection.Metadata;
+using Application.Exceptions;
+using Application.PiggyBanks.RemoveTransaction;
+using Application.Unit.Tests.TestUtilities;
+using Application.Unit.Tests.TestUtilities.Constants;
+using Domain.PiggyBanks;
+using Domain.Repositories;
+using Domain.Users;
+
+namespace Application.Unit.Tests.PiggyBanks.RemoveTransaction;
+
+public sealed class RemoveTransactionCommandHandlerTests
+{
+    private readonly RemoveTransactionCommandHandler _cut;
+
+    private readonly IPiggyBanksRepository _mockRepository;
+
+    public RemoveTransactionCommandHandlerTests()
+    {
+        _mockRepository = Substitute.For<IPiggyBanksRepository>();
+
+        _mockRepository
+            .GetById(
+                Arg.Is<PiggyBankId>(
+                    i => i.Value == Constants.PiggyBank.Id
+                ),
+                Arg.Is<UserId>(
+                    i => i.Value == Constants.User.Id
+                )
+            )
+            .Returns(PiggyBanksUtilities.CreatePiggyBank());
+
+        _cut = new RemoveTransactionCommandHandler(
+            _mockRepository
+        );
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenCalled_ShouldCallGetByIdOnRepositoryOnce()
+    {
+        // Arrange
+        var command = RemoveTransactionCommandUtilities.CreateCommand();
+
+        // Act
+        await _cut.HandleAsync(
+            command,
+            default
+        );
+
+        // Assert
+        await _mockRepository
+            .Received(1)
+            .GetById(
+                Arg.Is<PiggyBankId>(
+                    i => i.Value == Constants.PiggyBank.Id
+                ),
+                Arg.Is<UserId>(
+                    i => i.Value == Constants.User.Id
+                )
+            );
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenPiggyBankNotFound_ShouldThrowPiggyBankNotFoundException()
+    {
+        // Arrange
+        var command = new RemoveTransactionCommand(
+            Guid.NewGuid(),
+            Constants.Transaction.Id,
+            Constants.User.Id
+        );
+
+        var removeTransaction = async () => await _cut.HandleAsync(
+            command,
+            default
+        );
+
+        // Act & Assert
+        await removeTransaction
+            .Should()
+            .ThrowExactlyAsync<PiggyBankNotFoundException>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_OnSuccess_ShouldCallSaveOnRepositoryOnce()
+    {
+        // Arrange
+        PiggyBank passedArgument = null;
+        await _mockRepository
+            .Save(
+                Arg.Do<PiggyBank>(p => passedArgument = p)
+            );
+
+        var command = RemoveTransactionCommandUtilities.CreateCommand();
+
+        // Act
+        await _cut.HandleAsync(
+            command,
+            default
+        );
+
+        // Assert
+        await _mockRepository
+            .Received(1)
+            .Save(Arg.Is(passedArgument));
+
+        passedArgument?.Transactions
+            .Should()
+            .HaveCount(1);
+    }
+}

--- a/tests/Application.Unit.Tests/PiggyBanks/RemoveTransaction/RemoveTransactionCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/PiggyBanks/RemoveTransaction/RemoveTransactionCommandUtilities.cs
@@ -1,0 +1,14 @@
+using Application.PiggyBanks.RemoveTransaction;
+using Application.Unit.Tests.TestUtilities.Constants;
+
+namespace Application.Unit.Tests.PiggyBanks.RemoveTransaction;
+
+public static class RemoveTransactionCommandUtilities
+{
+    public static RemoveTransactionCommand CreateCommand()
+        => new(
+            Constants.PiggyBank.Id,
+            Constants.Transaction.Id,
+            Constants.User.Id
+        );
+}

--- a/tests/Application.Unit.Tests/TestUtilities/TransactionsUtilities.cs
+++ b/tests/Application.Unit.Tests/TestUtilities/TransactionsUtilities.cs
@@ -9,9 +9,9 @@ public static class TransactionsUtilities
     )
         => Enumerable.Range(0, index)
             .Select(r => new Transaction(
-                new(Constants.Constants.Transaction.IdFromIndex(index)),
-                Constants.Constants.Transaction.ValueFromIndex(index),
-                Constants.Constants.Transaction.DateFromIndex(index)
+                new(Constants.Constants.Transaction.IdFromIndex(r)),
+                Constants.Constants.Transaction.ValueFromIndex(r),
+                Constants.Constants.Transaction.DateFromIndex(r)
             ))
             .ToList();
 }

--- a/tests/Domain.Unit.Tests/PiggyBanks/PiggyBankTests.cs
+++ b/tests/Domain.Unit.Tests/PiggyBanks/PiggyBankTests.cs
@@ -178,4 +178,41 @@ public sealed class PiggyBankTests
             .Should()
             .ThrowExactly<TransactionAlreadyExistsException>();
     }
+
+    [Fact]
+    public void RemoveTransaction_WhenPassedProperData_ShouldRemoveTransactionFromPiggyBank()
+    {
+        // Arrange
+        var piggyBank = PiggyBankUtilities.CreatePiggyBank(
+            new List<Transaction>()
+            {
+                new Transaction(
+                    Constants.Transaction.Id,
+                    Constants.Transaction.Value,
+                    Constants.Transaction.Date
+                )
+            }
+        );
+
+        // Act
+        piggyBank.RemoveTransaction(Constants.Transaction.Id);
+
+        // Assert
+        piggyBank.Transactions
+            .Should()
+            .HaveCount(0);
+    }
+
+    [Fact]
+    public void RemoveTransaction_WhenTransactionWasntFound_ShouldThrowTransactionNotFoundException()
+    {
+        // Arrange
+        var piggyBank = PiggyBankUtilities.CreatePiggyBank();
+        var removeTransaction = () => piggyBank.RemoveTransaction(Constants.Transaction.Id);
+
+        // Act & Assert
+        removeTransaction
+            .Should()
+            .ThrowExactly<TransactionNotFoundException>();
+    }
 }

--- a/tests/Domain.Unit.Tests/PiggyBanks/TestUtilities/PiggyBankUtilities.cs
+++ b/tests/Domain.Unit.Tests/PiggyBanks/TestUtilities/PiggyBankUtilities.cs
@@ -1,15 +1,17 @@
+using System.Collections.Generic;
 using Domain.PiggyBanks;
 
 namespace Domain.Unit.Tests.PiggyBanks.TestUtilities;
 
 public static class PiggyBankUtilities
 {
-    public static PiggyBank CreatePiggyBank()
+    public static PiggyBank CreatePiggyBank(List<Transaction> transactions = null)
         => new(
             Constants.PiggyBank.Id,
             Constants.PiggyBank.Name,
             Constants.PiggyBank.WithGoal,
             Constants.PiggyBank.Goal,
-            Constants.PiggyBank.UserId
+            Constants.PiggyBank.UserId,
+            transactions
         );
 }


### PR DESCRIPTION
### What?

I'm adding ability to remove transactions from the piggy banks with resource:

```java
[DELETE] /api/piggy-bank/{piggyBankId}/transactions/{transactionId}
```

### Why?

In case of a users mistake there should be an option for removing transactions.

### How?

As always... using TDD technic from `Domain` layer to `WebAPI` layer.

Related to #89 