### PR TITLE
#98 Feature - `PiggyBank` details

### DIFF
--- a/src/Application/PiggyBanks/GetPiggyBankById/GetPiggyBankByIdQuery.cs
+++ b/src/Application/PiggyBanks/GetPiggyBankById/GetPiggyBankByIdQuery.cs
@@ -1,0 +1,8 @@
+using Application.Abstractions.CQRS;
+
+namespace Application.PiggyBanks.GetPiggyBankById;
+
+public sealed record GetPiggyBankByIdQuery(
+    Guid PiggyBankId,
+    Guid UserId
+) : IQuery<PiggyBankDTO>;

--- a/src/Application/PiggyBanks/GetPiggyBankById/GetPiggyBankByIdQueryHandler.cs
+++ b/src/Application/PiggyBanks/GetPiggyBankById/GetPiggyBankByIdQueryHandler.cs
@@ -1,0 +1,41 @@
+using Application.Abstractions.CQRS;
+using Application.Exceptions;
+using Application.PiggyBanks.Mappings;
+using Domain.PiggyBanks;
+using Domain.Repositories;
+using Domain.Users;
+
+namespace Application.PiggyBanks.GetPiggyBankById;
+
+public sealed class GetPiggyBankByIdQueryHandler
+    : IQueryHandler<GetPiggyBankByIdQuery, PiggyBankDTO>
+{
+    private readonly IPiggyBanksRepository _repository;
+
+    public GetPiggyBankByIdQueryHandler(IPiggyBanksRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<PiggyBankDTO> HandleAsync(
+        GetPiggyBankByIdQuery query,
+        CancellationToken token = default
+    )
+    {
+        PiggyBankId piggyBankId = new(query.PiggyBankId);
+        UserId userId = new(query.UserId);
+
+        var entity = await _repository.GetById(
+            piggyBankId,
+            userId,
+            token
+        );
+        
+        if (entity is null)
+        {
+            throw new PiggyBankNotFoundException(piggyBankId);
+        }
+
+        return entity?.ToDTO();
+    }
+}

--- a/src/Application/PiggyBanks/Mappings/PiggyBankMappings.cs
+++ b/src/Application/PiggyBanks/Mappings/PiggyBankMappings.cs
@@ -1,0 +1,25 @@
+using Domain.PiggyBanks;
+
+namespace Application.PiggyBanks.Mappings;
+
+public static class PiggyBankMappingsExtensions
+{
+    public static PiggyBankDTO? ToDTO(this PiggyBank domain)
+    {
+        if (domain is null)
+        {
+            return null;
+        }
+
+        return new PiggyBankDTO()
+        {
+            Id = domain.Id.Value,
+            Name = domain.Name.Value,
+            WithGoal = domain.WithGoal,
+            Goal = domain.Goal.Value,
+            Transactions = domain.Transactions
+                .Select(t => t.ToDTO())
+                .ToList()
+        };
+    }
+}

--- a/src/Application/PiggyBanks/Mappings/TransactionMappings.cs
+++ b/src/Application/PiggyBanks/Mappings/TransactionMappings.cs
@@ -1,0 +1,21 @@
+using Domain.PiggyBanks;
+
+namespace Application.PiggyBanks.Mappings;
+
+public static class TransactionMappingsExtensions
+{
+    public static TransactionDTO ToDTO(this Transaction domain)
+    {
+        if (domain is null)
+        {
+            return null;
+        }
+
+        return new TransactionDTO()
+        {
+            Id = domain.Id.Value,
+            Value = domain.Value,
+            Date = domain.Date
+        };
+    }
+}

--- a/src/Application/PiggyBanks/PiggyBankDTO.cs
+++ b/src/Application/PiggyBanks/PiggyBankDTO.cs
@@ -1,0 +1,10 @@
+namespace Application.PiggyBanks;
+
+public sealed class PiggyBankDTO
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; }
+    public bool WithGoal { get; set; }
+    public decimal Goal { get; set; }
+    public IEnumerable<TransactionDTO> Transactions { get; set; }
+}

--- a/src/Application/PiggyBanks/TransactionDTO.cs
+++ b/src/Application/PiggyBanks/TransactionDTO.cs
@@ -1,0 +1,8 @@
+namespace Application.PiggyBanks;
+
+public sealed class TransactionDTO
+{
+    public Guid Id { get; set; }
+    public decimal Value { get; set; }
+    public DateOnly Date { get; set; }
+}

--- a/tests/Application.Unit.Tests/PiggyBanks/GetPiggyBankById/GetPiggyBankByIdQueryHandlerTests.cs
+++ b/tests/Application.Unit.Tests/PiggyBanks/GetPiggyBankById/GetPiggyBankByIdQueryHandlerTests.cs
@@ -1,0 +1,122 @@
+using System.Security.Cryptography.X509Certificates;
+using Application.Exceptions;
+using Application.PiggyBanks;
+using Application.PiggyBanks.GetPiggyBankById;
+using Application.Unit.Tests.TestUtilities;
+using Application.Unit.Tests.TestUtilities.Constants;
+using Domain.PiggyBanks;
+using Domain.Repositories;
+using Domain.Users;
+
+namespace Application.Unit.Tests.PiggyBanks.GetPiggyBankById;
+
+public sealed class GetPiggyBankByIdQueryHandlerTests
+{
+    private readonly GetPiggyBankByIdQueryHandler _cut;
+
+    private readonly IPiggyBanksRepository _mockRepository;
+
+    public GetPiggyBankByIdQueryHandlerTests()
+    {
+        _mockRepository = Substitute.For<IPiggyBanksRepository>();
+
+        _mockRepository
+            .GetById(
+                Arg.Is<PiggyBankId>(
+                    i => i.Value == Constants.PiggyBank.Id
+                ),
+                Arg.Is<UserId>(
+                    i => i.Value == Constants.User.Id
+                )
+            )
+            .Returns(PiggyBanksUtilities.CreatePiggyBank());
+
+        _cut = new GetPiggyBankByIdQueryHandler(
+            _mockRepository
+        );
+    }
+    [Fact]
+    public async Task HandleAsync_WhenInvoked_ShouldCallGetByIdOnRepositoryOnce()
+    {
+        // Arrange
+        var query = GetPiggyBankByIdQueryUtilities.CreateQuery();
+
+        // Act
+        await _cut.HandleAsync(
+            query,
+            default
+        );
+
+        // Assert
+        await _mockRepository
+            .Received(1)
+            .GetById(
+                Arg.Is<PiggyBankId>(
+                    pi => pi.Value == Constants.PiggyBank.Id
+                ),
+                Arg.Is<UserId>(
+                    ui => ui.Value == Constants.User.Id
+                )
+            );
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenPiggyBankNotFound_ShouldThrowPiggyBankNotFoundException()
+    {
+        // Arrange
+        var query = new GetPiggyBankByIdQuery(
+            Guid.NewGuid(),
+            Guid.NewGuid()
+        );
+
+        var getPiggyBankById = async () => await _cut.HandleAsync(
+            query,
+            default
+        );
+
+        // Act & Assert
+        await getPiggyBankById
+            .Should()
+            .ThrowExactlyAsync<PiggyBankNotFoundException>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_OnSuccess_ShouldReturnExpectedObject()
+    {
+        // Arrange
+        var query = GetPiggyBankByIdQueryUtilities.CreateQuery();
+
+        // Act
+        var result = await _cut.HandleAsync(
+            query,
+            default
+        );
+
+        // Assert
+        result
+            .Should()
+            .NotBeNull();
+
+        result
+            .Should()
+            .BeEquivalentTo(
+                new PiggyBankDTO()
+                {
+                    Id = Constants.PiggyBank.Id,
+                    Name = Constants.PiggyBank.Name,
+                    WithGoal = Constants.PiggyBank.WithGoal,
+                    Goal = Constants.PiggyBank.Goal,
+                    Transactions = TransactionsUtilities
+                        .CreateTransactions()
+                        .Select(
+                            t => new TransactionDTO()
+                            {
+                                Id = t.Id.Value,
+                                Value = t.Value,
+                                Date = t.Date
+                            }
+                        )
+                }
+            );
+    }
+}

--- a/tests/Application.Unit.Tests/PiggyBanks/GetPiggyBankById/GetPiggyBankByIdQueryUtilities.cs
+++ b/tests/Application.Unit.Tests/PiggyBanks/GetPiggyBankById/GetPiggyBankByIdQueryUtilities.cs
@@ -1,0 +1,13 @@
+using Application.PiggyBanks.GetPiggyBankById;
+using Application.Unit.Tests.TestUtilities.Constants;
+
+namespace Application.Unit.Tests.PiggyBanks.GetPiggyBankById;
+
+public static class GetPiggyBankByIdQueryUtilities
+{
+    public static GetPiggyBankByIdQuery CreateQuery()
+        => new(
+            Constants.PiggyBank.Id,
+            Constants.User.Id
+        );
+}


### PR DESCRIPTION
### What?

I'm adding ability to get details about `PiggyBank` (all data and transactions) by its id with resource:

```java
[GET] /api/piggy-banks/{piggyBankId}
```

### Why?

There should be a resource allowing users to get data about piggy bank by ID for view.

Related to #98 