### PR TITLE
#101 Fix - Soft delete of the `Transaction`

### DIFF
--- a/src/Domain/Piggybanks/Piggybank.cs
+++ b/src/Domain/Piggybanks/Piggybank.cs
@@ -107,6 +107,6 @@ public sealed class PiggyBank
             throw new TransactionNotFoundException(transactionId);
         }
 
-        _transactions.Remove(transactionToRemove);
+        transactionToRemove.Remove();
     }
 }

--- a/src/Domain/Piggybanks/Transaction.cs
+++ b/src/Domain/Piggybanks/Transaction.cs
@@ -7,6 +7,7 @@ public sealed class Transaction
     public TransactionId Id { get; }
     public decimal Value { get; }
     public DateOnly Date { get; }
+    public bool Active { get; set; } = true;
 
     public Transaction(
         TransactionId id,
@@ -36,5 +37,10 @@ public sealed class Transaction
         {
             throw new TransactionValueEqualToZeroException();
         }
+    }
+
+    public void Remove()
+    {
+        Active = false;
     }
 }

--- a/src/Infrastructure/Migrations/20231201115402_Adding activity flag for transaction..Designer.cs
+++ b/src/Infrastructure/Migrations/20231201115402_Adding activity flag for transaction..Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistance;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(SmugetDbContext))]
-    partial class SmugetDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231201115402_Adding activity flag for transaction.")]
+    partial class Addingactivityflagfortransaction
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20231201115402_Adding activity flag for transaction..cs
+++ b/src/Infrastructure/Migrations/20231201115402_Adding activity flag for transaction..cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class Addingactivityflagfortransaction : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "Active",
+                table: "Transactions",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Active",
+                table: "Transactions");
+        }
+    }
+}

--- a/src/Infrastructure/Persistance/Configurations/TransactionEntityConfiguration.cs
+++ b/src/Infrastructure/Persistance/Configurations/TransactionEntityConfiguration.cs
@@ -30,5 +30,9 @@ internal sealed class TransactionEntityConfiguration
         builder
             .Property(p => p.PiggyBankId)
             .IsRequired();
+
+        builder
+            .Property(t => t.Active)
+            .IsRequired();
     }
 }

--- a/src/Infrastructure/Persistance/Entities/Mappings/PiggyBankMappingExtensions.cs
+++ b/src/Infrastructure/Persistance/Entities/Mappings/PiggyBankMappingExtensions.cs
@@ -18,6 +18,8 @@ internal static class PiggyBankMappingExtensions
             new(entity.Goal),
             new(entity.UserId),
             entity.Transactions
+                .Where(t => t.Active)
+                .ToList()
                 .ConvertAll(t => t.ToDomain())
         );
     }

--- a/src/Infrastructure/Persistance/Entities/Mappings/TransactionMappingExtensions.cs
+++ b/src/Infrastructure/Persistance/Entities/Mappings/TransactionMappingExtensions.cs
@@ -28,7 +28,8 @@ internal static class TransactionMappingExtensions
             Id = domain.Id.Value,
             Value = domain.Value,
             Date = domain.Date,
-            PiggyBankId = piggyBankId
+            PiggyBankId = piggyBankId,
+            Active = domain.Active
         };
     }
 }

--- a/src/Infrastructure/Persistance/Entities/TransactionEntity.cs
+++ b/src/Infrastructure/Persistance/Entities/TransactionEntity.cs
@@ -6,4 +6,5 @@ internal sealed class TransactionEntity
     public decimal Value { get; set; }
     public DateOnly Date { get; set; }
     public Guid PiggyBankId { get; set; }
+    public bool Active { get; set; }
 }

--- a/tests/Application.Unit.Tests/PiggyBanks/RemoveTransaction/RemoveTransactionCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/PiggyBanks/RemoveTransaction/RemoveTransactionCommandHandlerTests.cs
@@ -28,7 +28,7 @@ public sealed class RemoveTransactionCommandHandlerTests
                     i => i.Value == Constants.User.Id
                 )
             )
-            .Returns(PiggyBanksUtilities.CreatePiggyBank());
+            .Returns(PiggyBanksUtilities.CreatePiggyBank(TransactionsUtilities.CreateTransactions(1).ToList()));
 
         _cut = new RemoveTransactionCommandHandler(
             _mockRepository

--- a/tests/Domain.Unit.Tests/PiggyBanks/PiggyBankTests.cs
+++ b/tests/Domain.Unit.Tests/PiggyBanks/PiggyBankTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Domain.Exceptions;
 using Domain.PiggyBanks;
 using Domain.Unit.Tests.PiggyBanks.TestUtilities;
@@ -200,7 +201,12 @@ public sealed class PiggyBankTests
         // Assert
         piggyBank.Transactions
             .Should()
-            .HaveCount(0);
+            .HaveCount(1);
+
+        piggyBank.Transactions
+            .First().Active
+                .Should()
+                .BeFalse();
     }
 
     [Fact]

--- a/tests/Domain.Unit.Tests/PiggyBanks/TestUtilities/Constants.Transaction.cs
+++ b/tests/Domain.Unit.Tests/PiggyBanks/TestUtilities/Constants.Transaction.cs
@@ -7,8 +7,9 @@ public static partial class Constants
 {
     public static class Transaction
     {
-        public static readonly TransactionId Id = new(new Guid(0, 0, 0, new byte[] { 0, 0, 0, 0, 0, 0, 0, 1}));
+        public static readonly TransactionId Id = new(new Guid(0, 0, 0, new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }));
         public const decimal Value = 215.90m;
         public static readonly DateOnly Date = new DateOnly(2023, 11, 11);
+        public const bool Active = true;
     }
 }

--- a/tests/Domain.Unit.Tests/PiggyBanks/TransactionTests.cs
+++ b/tests/Domain.Unit.Tests/PiggyBanks/TransactionTests.cs
@@ -26,6 +26,7 @@ public sealed class TransactionTests
                 t => t.Id == Constants.Transaction.Id
                   && t.Value == Constants.Transaction.Value
                   && t.Date == Constants.Transaction.Date
+                  && t.Active == Constants.Transaction.Active
             );
     }
 
@@ -59,5 +60,20 @@ public sealed class TransactionTests
         createTransaction
             .Should()
             .ThrowExactly<TransactionValueEqualToZeroException>();
+    }
+
+    [Fact]
+    public void Remove_WhenCalled_ShouldChangeActiveToFalse()
+    {
+        // Arrange
+        var transaction = TransactionUtilities.CreateTransaction();
+
+        // Act
+        transaction.Remove();
+
+        // Assert
+        transaction.Active
+            .Should()
+            .BeFalse();
     }
 }


### PR DESCRIPTION
### What?

I'm adding changes that fixed `Transaction` removing from `PiggyBank`. Instead of 'hard delete' they are deactivated (soft deleted).

### Why?

This was a mistake. Data should be there for auditing for a certain amount of time.

Related to #101 