### PR TITLE
#88 Feature - IP address request rate limit

### DIFF
--- a/src/WebAPI/Extensions/AddRateLimitingExtension.cs
+++ b/src/WebAPI/Extensions/AddRateLimitingExtension.cs
@@ -1,0 +1,38 @@
+﻿using Infrastructure.Exceptions;
+using Microsoft.AspNetCore.RateLimiting;
+using System.Threading.RateLimiting;
+
+namespace WebAPI.Extensions;
+
+public static class AddRateLimitingExtension
+{
+    public static IApplicationBuilder UseRateLimiting(this IApplicationBuilder app)
+        => app.UseRateLimiter(new RateLimiterOptions
+        {
+            GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(
+            context =>
+            {
+                return RateLimitPartition.GetFixedWindowLimiter(
+                    context.Request.Headers["X-Forwarded-For"].ToString(),
+                    httpContext => new FixedWindowRateLimiterOptions()
+                    {
+                        PermitLimit = 2,
+                        QueueLimit = 0,
+                        AutoReplenishment = true,
+                        Window = TimeSpan.FromSeconds(1)
+                    });
+            }),
+
+            OnRejected = async (context, h) =>
+            {
+                context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+                await context.HttpContext.Response.WriteAsJsonAsync(
+                    new Error(
+                        "Too many requests. There is a limit of 2 requests per second.",
+                        "TooManyRequests",
+                        context.HttpContext.Request.Path
+                    )
+                );
+            }
+        });
+}

--- a/src/WebAPI/Program.cs
+++ b/src/WebAPI/Program.cs
@@ -3,9 +3,6 @@ using Application;
 using Infrastructure;
 using WebAPI.Middlewares;
 using WebAPI.Services.Users;
-using Microsoft.AspNetCore.RateLimiting;
-using System.Threading.RateLimiting;
-using Infrastructure.Exceptions;
 using WebAPI.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/src/WebAPI/Program.cs
+++ b/src/WebAPI/Program.cs
@@ -3,6 +3,10 @@ using Application;
 using Infrastructure;
 using WebAPI.Middlewares;
 using WebAPI.Services.Users;
+using Microsoft.AspNetCore.RateLimiting;
+using System.Threading.RateLimiting;
+using Infrastructure.Exceptions;
+using WebAPI.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 {
@@ -39,6 +43,7 @@ var app = builder.Build();
     app.UseAuthorization();
 
     app.MapControllers();
+    app.UseRateLimiting();
 
     app.Run();
 }


### PR DESCRIPTION
### What?

I've added rate limiting policy for every user's IP address.

### Why?

Before releasing the API and publishing it I want to have some level of certanity, that no-one can easily DDoS this API.

### How?

I am using `Microsoft.AspNetCore.RateLimiting` package from .NET. \
I set the policy to 2 requests per second PER IP Address. \
The IP Address is read from 'X-Forwarder-For' header, because my API will be published on VPS with reverse proxy.

Related to #88 