### PR TITLE
#109 Refactor - "Allowing to have multiple login session opened for user"

### DIFF
--- a/src/Application/Identity/Login/LoginCommand.cs
+++ b/src/Application/Identity/Login/LoginCommand.cs
@@ -4,5 +4,6 @@ namespace Application.Identity.Login;
 
 public sealed record LoginCommand(
     string Email,
-    string Password
+    string Password,
+    string IpAddress
 ) : ICommand;

--- a/src/Application/Identity/Login/LoginCommandHandler.cs
+++ b/src/Application/Identity/Login/LoginCommandHandler.cs
@@ -59,6 +59,7 @@ public sealed class LoginCommandHandler
             token.Id,
             token.CreationDateTime,
             token.ExpirationDateTime,
+            command.IpAddress,
             false,
             false,
             entity.Id

--- a/src/Application/Identity/Login/LoginCommandHandler.cs
+++ b/src/Application/Identity/Login/LoginCommandHandler.cs
@@ -51,13 +51,6 @@ public sealed class LoginCommandHandler
             throw new InvalidCredentialsException();
         }
 
-        var existingRefreshToken = await _refreshTokensRepository.GetActiveByUserId(entity.Id.Value);
-
-        if (existingRefreshToken is not null)
-        {
-            throw new UserAlreadyLoggedInException();
-        }
-
         var token = _authenticator.CreateToken(entity);
 
         var refreshTokenEntity = new RefreshToken(

--- a/src/Application/Identity/Refresh/RefreshCommand.cs
+++ b/src/Application/Identity/Refresh/RefreshCommand.cs
@@ -4,5 +4,6 @@ namespace Application.Identity.Refresh;
 
 public sealed record RefreshCommand(
     string AccessToken,
-    string RefreshToken
+    string RefreshToken,
+    string IpAddess
 ) : ICommand;

--- a/src/Application/Identity/Refresh/RefreshCommandHandler.cs
+++ b/src/Application/Identity/Refresh/RefreshCommandHandler.cs
@@ -72,7 +72,8 @@ public sealed class RefreshCommandHandler
             command.IpAddess,
             false,
             false,
-            user.Id
+            user.Id,
+            existingRefreshToken.Id
         );
 
         existingRefreshToken.Use();

--- a/src/Application/Identity/Refresh/RefreshCommandHandler.cs
+++ b/src/Application/Identity/Refresh/RefreshCommandHandler.cs
@@ -69,6 +69,7 @@ public sealed class RefreshCommandHandler
             token.Id,
             token.CreationDateTime,
             token.ExpirationDateTime,
+            command.IpAddess,
             false,
             false,
             user.Id

--- a/src/Domain/Exceptions/InvalidIpAddressException.cs
+++ b/src/Domain/Exceptions/InvalidIpAddressException.cs
@@ -1,0 +1,9 @@
+﻿namespace Domain.Exceptions
+{
+    internal class InvalidIpAddressException
+        : SmugetException
+    {
+        public InvalidIpAddressException()
+            : base("IP address cannot be null or whitespace.") { }
+    }
+}

--- a/src/Domain/RefreshTokens/RefreshToken.cs
+++ b/src/Domain/RefreshTokens/RefreshToken.cs
@@ -10,6 +10,7 @@ public sealed class RefreshToken
     public Guid JwtId { get; }
     public DateTime CreationDateTime { get; }
     public DateTime ExpirationDateTime { get; }
+    public string IssuedFrom { get; set; }
     public bool Used { get; private set; }
     public bool Invalidated { get; private set; }
     public UserId UserId { get; }
@@ -20,6 +21,7 @@ public sealed class RefreshToken
         Guid jwtId,
         DateTime creationDateTime,
         DateTime expirationDateTime,
+        string ipAddress,
         bool used,
         bool invalidated,
         UserId userId
@@ -28,12 +30,14 @@ public sealed class RefreshToken
         ThrowIfRefreshTokenIdIsNull(refreshTokenId);
         ThrowIfTokenIsNullOrWhiteSpace(token);
         ThrowIfUserIdIsNull(userId);
+        ThrowIfIpAddressIsNullOrWhiteSpace(ipAddress);
 
         Id = refreshTokenId;
         Token = token;
         JwtId = jwtId;
         CreationDateTime = creationDateTime;
         ExpirationDateTime = expirationDateTime;
+        IssuedFrom = ipAddress;
         Used = used;
         Invalidated = invalidated;
         UserId = userId;
@@ -66,6 +70,14 @@ public sealed class RefreshToken
         if (userId is null)
         {
             throw new UserIdIsNullException();
+        }
+    }
+
+    private void ThrowIfIpAddressIsNullOrWhiteSpace(string ipAddress)
+    {
+        if (string.IsNullOrWhiteSpace(ipAddress))
+        {
+            throw new InvalidIpAddressException();
         }
     }
 }

--- a/src/Domain/RefreshTokens/RefreshToken.cs
+++ b/src/Domain/RefreshTokens/RefreshToken.cs
@@ -14,6 +14,7 @@ public sealed class RefreshToken
     public bool Used { get; private set; }
     public bool Invalidated { get; private set; }
     public UserId UserId { get; }
+    public RefreshTokenId? RefreshedBy { get; private set; }
 
     public RefreshToken(
         RefreshTokenId refreshTokenId,
@@ -24,7 +25,8 @@ public sealed class RefreshToken
         string ipAddress,
         bool used,
         bool invalidated,
-        UserId userId
+        UserId userId,
+        RefreshTokenId? refreshedBy = null
     )
     {
         ThrowIfRefreshTokenIdIsNull(refreshTokenId);
@@ -41,6 +43,7 @@ public sealed class RefreshToken
         Used = used;
         Invalidated = invalidated;
         UserId = userId;
+        RefreshedBy = refreshedBy;
     }
 
     public void Use()

--- a/src/Domain/RefreshTokens/RefreshToken.cs
+++ b/src/Domain/RefreshTokens/RefreshToken.cs
@@ -52,6 +52,9 @@ public sealed class RefreshToken
     public void Invalidate()
         => Invalidated = true;
 
+    public bool IsActive()
+        => !Invalidated && !Used;
+
     private void ThrowIfRefreshTokenIdIsNull(RefreshTokenId refreshTokenId)
     {
         if (refreshTokenId is null)

--- a/src/Domain/Repositories/IRefreshTokensRepository.cs
+++ b/src/Domain/Repositories/IRefreshTokensRepository.cs
@@ -6,5 +6,6 @@ public interface IRefreshTokensRepository
 {
     Task<RefreshToken?> Get(string token);
     Task<RefreshToken?> GetActiveByUserId(Guid id);
+    Task<RefreshToken?> GetByRefreshedBy(Guid refreshedBy);
     Task Save(RefreshToken refreshToken);
 }

--- a/src/Infrastructure/Authentication/Authenticator.cs
+++ b/src/Infrastructure/Authentication/Authenticator.cs
@@ -8,7 +8,6 @@ using Application.Exceptions;
 using Application.Identity;
 using Domain.Users;
 using Infrastructure.Exceptions;
-using Infrastructure.Time;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 

--- a/src/Infrastructure/Migrations/20240412082118_AddingIpAddressForLoginAndRefresh.Designer.cs
+++ b/src/Infrastructure/Migrations/20240412082118_AddingIpAddressForLoginAndRefresh.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistance;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(SmugetDbContext))]
-    partial class SmugetDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240412082118_AddingIpAddressForLoginAndRefresh")]
+    partial class AddingIpAddressForLoginAndRefresh
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20240412082118_AddingIpAddressForLoginAndRefresh.cs
+++ b/src/Infrastructure/Migrations/20240412082118_AddingIpAddressForLoginAndRefresh.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddingIpAddressForLoginAndRefresh : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "IssuedFrom",
+                table: "RefreshTokens",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IssuedFrom",
+                table: "RefreshTokens");
+        }
+    }
+}

--- a/src/Infrastructure/Migrations/20240412103358_AddingRefereshedByColumn.Designer.cs
+++ b/src/Infrastructure/Migrations/20240412103358_AddingRefereshedByColumn.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistance;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(SmugetDbContext))]
-    partial class SmugetDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240412103358_AddingRefereshedByColumn")]
+    partial class AddingRefereshedByColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20240412103358_AddingRefereshedByColumn.cs
+++ b/src/Infrastructure/Migrations/20240412103358_AddingRefereshedByColumn.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddingRefereshedByColumn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "RefreshedBy",
+                table: "RefreshTokens",
+                type: "uuid",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RefreshedBy",
+                table: "RefreshTokens");
+        }
+    }
+}

--- a/src/Infrastructure/Persistance/Entities/Mappings/RefreshTokenMappingExtensions.cs
+++ b/src/Infrastructure/Persistance/Entities/Mappings/RefreshTokenMappingExtensions.cs
@@ -17,6 +17,7 @@ internal static class RefreshTokenMappingExtensions
             entity.JwtId,
             entity.CreationDateTime,
             entity.ExpirationDateTime,
+            entity.IssuedFrom,
             entity.Used,
             entity.Invalidated,
             new(entity.UserId)
@@ -32,6 +33,7 @@ internal static class RefreshTokenMappingExtensions
             JwtId = domain.JwtId,
             CreationDateTime = domain.CreationDateTime,
             ExpirationDateTime = domain.ExpirationDateTime,
+            IssuedFrom = domain.IssuedFrom,
             Used = domain.Used,
             Invalidated = domain.Invalidated,
             UserId = domain.UserId.Value

--- a/src/Infrastructure/Persistance/Entities/Mappings/RefreshTokenMappingExtensions.cs
+++ b/src/Infrastructure/Persistance/Entities/Mappings/RefreshTokenMappingExtensions.cs
@@ -20,7 +20,8 @@ internal static class RefreshTokenMappingExtensions
             entity.IssuedFrom,
             entity.Used,
             entity.Invalidated,
-            new(entity.UserId)
+            new(entity.UserId),
+            entity.RefreshedBy.HasValue ? new(entity.RefreshedBy.Value) : null
         );
     }
 
@@ -36,7 +37,8 @@ internal static class RefreshTokenMappingExtensions
             IssuedFrom = domain.IssuedFrom,
             Used = domain.Used,
             Invalidated = domain.Invalidated,
-            UserId = domain.UserId.Value
+            UserId = domain.UserId.Value,
+            RefreshedBy = domain.RefreshedBy?.Value
         };
     }
 }

--- a/src/Infrastructure/Persistance/Entities/RefreshTokenEntity.cs
+++ b/src/Infrastructure/Persistance/Entities/RefreshTokenEntity.cs
@@ -11,4 +11,5 @@ internal sealed class RefreshTokenEntity
     public bool Used { get; set; }
     public bool Invalidated { get; set; }
     public Guid UserId { get; set; }
+    public Guid? RefreshedBy { get; set; }
 }

--- a/src/Infrastructure/Persistance/Entities/RefreshTokenEntity.cs
+++ b/src/Infrastructure/Persistance/Entities/RefreshTokenEntity.cs
@@ -7,6 +7,7 @@ internal sealed class RefreshTokenEntity
     public Guid JwtId { get; set; }
     public DateTime CreationDateTime { get; set; }
     public DateTime ExpirationDateTime { get; set; }
+    public string IssuedFrom { get; set; }
     public bool Used { get; set; }
     public bool Invalidated { get; set; }
     public Guid UserId { get; set; }

--- a/src/Infrastructure/Persistance/Repositories/RefreshTokensRepository.cs
+++ b/src/Infrastructure/Persistance/Repositories/RefreshTokensRepository.cs
@@ -48,6 +48,18 @@ internal sealed class RefreshTokensRepository
             .ToDomain();
     }
 
+    public async Task<RefreshToken?> GetByRefreshedBy(Guid refreshedBy)
+    {
+        var entity = await _dbContext.RefreshTokens
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                r => r.RefreshedBy == refreshedBy
+            );
+
+        return entity?
+            .ToDomain();
+    }
+
     public async Task Save(RefreshToken refreshToken)
     {
         var newEntity = refreshToken.ToEntity();

--- a/src/WebAPI/Identity/AuthenticationResponse.cs
+++ b/src/WebAPI/Identity/AuthenticationResponse.cs
@@ -2,5 +2,6 @@ namespace WebAPI.Identity;
 
 public sealed record AuthenticationResponse(
     string AccessToken,
-    string RefreshToken
+    string RefreshToken,
+    DateTime AccessTokenExpiry
 );

--- a/src/WebAPI/Identity/AuthenticationResponse.cs
+++ b/src/WebAPI/Identity/AuthenticationResponse.cs
@@ -2,6 +2,5 @@ namespace WebAPI.Identity;
 
 public sealed record AuthenticationResponse(
     string AccessToken,
-    string RefreshToken,
-    DateTime AccessTokenExpiry
+    string RefreshToken
 );

--- a/src/WebAPI/Identity/IdentityController.cs
+++ b/src/WebAPI/Identity/IdentityController.cs
@@ -108,7 +108,8 @@ public sealed class IdentityController
         var jwtToken = _tokenStorage.Get();
         return Ok(new AuthenticationResponse(
             jwtToken.AccessToken,
-            jwtToken.RefreshToken
+            jwtToken.RefreshToken,
+            jwtToken.ExpirationDateTime
         ));
     }
 
@@ -143,7 +144,8 @@ public sealed class IdentityController
         var jwtToken = _tokenStorage.Get();
         return Ok(new AuthenticationResponse(
             jwtToken.AccessToken,
-            jwtToken.RefreshToken
+            jwtToken.RefreshToken,
+            jwtToken.ExpirationDateTime
         ));
     }
 

--- a/src/WebAPI/Identity/IdentityController.cs
+++ b/src/WebAPI/Identity/IdentityController.cs
@@ -1,5 +1,6 @@
 using Application.Abstractions.Authentication;
 using Application.Abstractions.CQRS;
+using Application.Exceptions;
 using Application.Identity.Login;
 using Application.Identity.Logout;
 using Application.Identity.Refresh;
@@ -90,10 +91,16 @@ public sealed class IdentityController
     {
         var (email, password) = request;
 
+        if (string.IsNullOrWhiteSpace(_userService.IpAddress))
+        {
+            throw new SourceAddressNotFoundException();
+        }
+
         await _login.HandleAsync(
             new LoginCommand(
                 email,
-                password
+                password,
+                _userService.IpAddress
             ),
             token
         );
@@ -119,10 +126,16 @@ public sealed class IdentityController
     {
         var (accessToken, refreshToken) = request;
 
+        if (string.IsNullOrWhiteSpace(_userService.IpAddress))
+        {
+            throw new SourceAddressNotFoundException();
+        }
+
         await _refresh.HandleAsync(
             new RefreshCommand(
                 accessToken,
-                refreshToken
+                refreshToken,
+                _userService.IpAddress
             ),
             token
         );

--- a/src/WebAPI/Identity/IdentityController.cs
+++ b/src/WebAPI/Identity/IdentityController.cs
@@ -108,8 +108,7 @@ public sealed class IdentityController
         var jwtToken = _tokenStorage.Get();
         return Ok(new AuthenticationResponse(
             jwtToken.AccessToken,
-            jwtToken.RefreshToken,
-            jwtToken.ExpirationDateTime
+            jwtToken.RefreshToken
         ));
     }
 
@@ -144,8 +143,7 @@ public sealed class IdentityController
         var jwtToken = _tokenStorage.Get();
         return Ok(new AuthenticationResponse(
             jwtToken.AccessToken,
-            jwtToken.RefreshToken,
-            jwtToken.ExpirationDateTime
+            jwtToken.RefreshToken
         ));
     }
 

--- a/src/WebAPI/Identity/SourceAddressNotFoundException.cs
+++ b/src/WebAPI/Identity/SourceAddressNotFoundException.cs
@@ -1,0 +1,11 @@
+﻿using Application.Exceptions;
+
+namespace WebAPI.Identity
+{
+    public class SourceAddressNotFoundException
+        : IdentityException
+    {
+        public SourceAddressNotFoundException()
+            : base("Remote IP address not found.") { }
+    }
+}

--- a/src/WebAPI/Services/Users/IUserService.cs
+++ b/src/WebAPI/Services/Users/IUserService.cs
@@ -3,4 +3,5 @@ namespace WebAPI.Services.Users;
 public interface IUserService
 {
     Guid UserId { get; }
+    string? IpAddress { get; }
 }

--- a/src/WebAPI/Services/Users/UserService.cs
+++ b/src/WebAPI/Services/Users/UserService.cs
@@ -14,4 +14,7 @@ public sealed class UserService
     public Guid UserId
         => Guid.Parse(_httpContext.User.Identity?.Name
             ?? throw new UserIdentityNotFoundException());
+
+    public string? IpAddress
+        => _httpContext?.Connection?.RemoteIpAddress?.MapToIPv4()?.ToString();
 }

--- a/tests/Application.Unit.Tests/Identity/Login/LoginCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/Identity/Login/LoginCommandHandlerTests.cs
@@ -96,7 +96,8 @@ public sealed class LoginCommandHandlerTests
         // Arrange
         var login = new LoginCommand(
             "notfounduser@example.com",
-            "P@$w0rd1."
+            "P@$w0rd1.",
+            "192.168.0.1"
         );
 
         var loginAction = () => _cut.HandleAsync(
@@ -135,7 +136,8 @@ public sealed class LoginCommandHandlerTests
         // Arrange
         var login = new LoginCommand(
             Constants.User.Email,
-            "password"
+            "password",
+            Constants.User.IpAddress
         );
 
         var loginAction = () => _cut.HandleAsync(
@@ -145,28 +147,6 @@ public sealed class LoginCommandHandlerTests
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidCredentialsException>(loginAction);
-    }
-
-    [Fact]
-    public async Task HandleAsync_WhenUserPasswordValidatedSuccessfully_ShouldCallGetActiveByUserIdOnRefreshTokensRepositoryOnce()
-    {
-        // Arrange
-        var login = LoginCommandUtilities.CreateCommand();
-
-        // Act
-        await _cut.HandleAsync(
-            login,
-            default
-        );
-
-        // Assert
-        await _refreshTokensRepository
-            .Received(1)
-            .GetActiveByUserId(
-                Arg.Is<Guid>(
-                    g => g == Constants.User.Id
-                )
-            );
     }
 
     [Fact]

--- a/tests/Application.Unit.Tests/Identity/Login/LoginCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/Identity/Login/LoginCommandHandlerTests.cs
@@ -170,26 +170,6 @@ public sealed class LoginCommandHandlerTests
     }
 
     [Fact]
-    public async Task HandleAsync_WhenUserAlreadyHasRefreshToken_ShouldThrowUserAlreadyLoggedInException()
-    {
-        // Arrange
-        var login = LoginCommandUtilities.CreateCommand();
-
-        _refreshTokensRepository
-            .GetActiveByUserId(Constants.User.Id)
-            .Returns(RefreshTokensUtilities.CreateRefreshToken());
-
-        var loginAction = () => _cut.HandleAsync(
-            login,
-            default
-        );
-
-        // Act & Assert
-        await Assert.ThrowsAsync<UserAlreadyLoggedInException>(loginAction);
-
-    }
-
-    [Fact]
     public async Task HandleAsync_WhenUsersPasswordValidatedSuccessfully_ShouldCallCreateTokenOnAuthenticatorOnce()
     {
         // Arrange

--- a/tests/Application.Unit.Tests/Identity/Login/LoginCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/Identity/Login/LoginCommandUtilities.cs
@@ -8,6 +8,7 @@ public static class LoginCommandUtilities
     public static LoginCommand CreateCommand()
         => new(
             Constants.User.Email,
-            Constants.User.Password
+            Constants.User.Password,
+            Constants.User.IpAddress
         );
 }

--- a/tests/Application.Unit.Tests/Identity/Refresh/RefreshCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/Identity/Refresh/RefreshCommandHandlerTests.cs
@@ -327,7 +327,7 @@ public sealed class RefreshCommandHandlerTests
 
 		// Assert
 		refreshTokens.Should().HaveCount(2);
-		var newToken = refreshTokens.Single(rt => rt.RefreshedBy is null);
-		refreshTokens.Should().ContainSingle(c => c.RefreshedBy == newToken.Id);
+		var existingToken = refreshTokens.Single(rt => rt.RefreshedBy is null);
+		refreshTokens.Should().ContainSingle(c => c.RefreshedBy == existingToken.Id);
 	}
 }

--- a/tests/Application.Unit.Tests/Identity/Refresh/RefreshCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/Identity/Refresh/RefreshCommandHandlerTests.cs
@@ -116,7 +116,8 @@ public sealed class RefreshCommandHandlerTests
 		// Arrange
 		var command = new RefreshCommand(
 			"abc123",
-			"123def"
+			"123def",
+			"192.168.2.1"
 		);
 
 		var commandAction = () => _cut.HandleAsync(
@@ -156,8 +157,9 @@ public sealed class RefreshCommandHandlerTests
 		// Arrange
 		var command = new RefreshCommand(
 			Constants.User.AccessToken,
-			"token-for-other-user"
-		);
+			"token-for-other-user",
+            Constants.User.IpAddress
+        );
 
 		var commandAction = () => _cut.HandleAsync(
 			command,
@@ -174,7 +176,8 @@ public sealed class RefreshCommandHandlerTests
 		// Arrange
 		var command = new RefreshCommand(
 			Constants.User.AccessToken,
-			"used-token"
+			"used-token",
+			Constants.User.IpAddress
 		);
 
 		var commandAction = () => _cut.HandleAsync(
@@ -192,8 +195,9 @@ public sealed class RefreshCommandHandlerTests
 		// Arrange
 		var command = new RefreshCommand(
 			Constants.User.AccessToken,
-			"invalidated-token"
-		);
+			"invalidated-token",
+            Constants.User.IpAddress
+        );
 
 		var commandAction = () => _cut.HandleAsync(
 			command,
@@ -210,8 +214,9 @@ public sealed class RefreshCommandHandlerTests
 		// Arrange
 		var command = new RefreshCommand(
 			Constants.User.AccessToken,
-			"expired-token"
-		);
+			"expired-token",
+            Constants.User.IpAddress
+        );
 
 		var commandAction = () => _cut.HandleAsync(
 			command,

--- a/tests/Application.Unit.Tests/Identity/Refresh/RefreshCommandHandlerTests.cs
+++ b/tests/Application.Unit.Tests/Identity/Refresh/RefreshCommandHandlerTests.cs
@@ -309,4 +309,25 @@ public sealed class RefreshCommandHandlerTests
 				)
 			);
 	}
+
+	[Fact]
+	public async Task HandleAsync_WhenTokenSuccessfullyRefreshed_ShouldSaveRefreshedByProperty()
+	{
+        // Arrange
+        var refreshTokens = new List<RefreshToken>();
+		await _refreshTokensRepository.Save(Arg.Do<RefreshToken>(refreshTokens.Add));
+
+		var command = RefreshCommandUtilities.CreateCommand();
+
+		// Act
+		await _cut.HandleAsync(
+			command,
+			default
+		);
+
+		// Assert
+		refreshTokens.Should().HaveCount(2);
+		var newToken = refreshTokens.Single(rt => rt.RefreshedBy is null);
+		refreshTokens.Should().ContainSingle(c => c.RefreshedBy == newToken.Id);
+	}
 }

--- a/tests/Application.Unit.Tests/Identity/Refresh/RefreshCommandUtilities.cs
+++ b/tests/Application.Unit.Tests/Identity/Refresh/RefreshCommandUtilities.cs
@@ -8,6 +8,7 @@ public static class RefreshCommandUtilities
     public static RefreshCommand CreateCommand()
         => new(
             Constants.User.AccessToken,
-            Constants.RefreshToken.Token
+            Constants.RefreshToken.Token,
+            Constants.User.IpAddress
         );
 }

--- a/tests/Application.Unit.Tests/TestUtilities/Constants/Constants.User.cs
+++ b/tests/Application.Unit.Tests/TestUtilities/Constants/Constants.User.cs
@@ -10,5 +10,6 @@ public static partial class Constants
         public const string Password = "P@$sw0rd1";
         public const string SecuredPassword = "4a6fafec30def6bfe3ac4e8a538810ff";
         public const string AccessToken = "WTo/eWQn2xu/imQaWx1c/A==";
+        public const string IpAddress = "192.172.10.1";
     }
 }

--- a/tests/Application.Unit.Tests/TestUtilities/RefreshTokensUtilities.cs
+++ b/tests/Application.Unit.Tests/TestUtilities/RefreshTokensUtilities.cs
@@ -11,6 +11,7 @@ public static class RefreshTokensUtilities
             Constants.Constants.RefreshToken.JwtId,
             Constants.Constants.RefreshToken.CreationDateTime,
             Constants.Constants.RefreshToken.ExpirationDateTime,
+            Constants.Constants.User.IpAddress,
             Constants.Constants.RefreshToken.Used,
             Constants.Constants.RefreshToken.Invalidated,
             new(Constants.Constants.User.Id)
@@ -23,6 +24,7 @@ public static class RefreshTokensUtilities
             Constants.Constants.RefreshToken.JwtId,
             Constants.Constants.RefreshToken.CreationDateTime,
             DateTime.Now.AddDays(-1),
+            Constants.Constants.User.IpAddress,
             Constants.Constants.RefreshToken.Used,
             Constants.Constants.RefreshToken.Invalidated,
             new(Constants.Constants.User.Id)
@@ -35,6 +37,7 @@ public static class RefreshTokensUtilities
             Constants.Constants.RefreshToken.JwtId,
             Constants.Constants.RefreshToken.CreationDateTime,
             Constants.Constants.RefreshToken.ExpirationDateTime,
+            Constants.Constants.User.IpAddress,
             true,
             Constants.Constants.RefreshToken.Invalidated,
             new(Constants.Constants.User.Id)
@@ -47,6 +50,7 @@ public static class RefreshTokensUtilities
             Constants.Constants.RefreshToken.JwtId,
             Constants.Constants.RefreshToken.CreationDateTime,
             Constants.Constants.RefreshToken.ExpirationDateTime,
+            Constants.Constants.User.IpAddress,
             Constants.Constants.RefreshToken.Used,
             true,
             new(Constants.Constants.User.Id)
@@ -59,6 +63,7 @@ public static class RefreshTokensUtilities
             Constants.Constants.RefreshToken.JwtId,
             Constants.Constants.RefreshToken.CreationDateTime,
             Constants.Constants.RefreshToken.ExpirationDateTime,
+            Constants.Constants.User.IpAddress,
             Constants.Constants.RefreshToken.Used,
             Constants.Constants.RefreshToken.Invalidated,
             new(new Guid(21, 12, 5, new byte[] { 0, 9, 1, 3, 2, 5, 32, 22 }))

--- a/tests/Domain.Unit.Tests/RefreshTokens/RefreshTokenTests.cs
+++ b/tests/Domain.Unit.Tests/RefreshTokens/RefreshTokenTests.cs
@@ -16,6 +16,7 @@ public sealed class RefreshTokenTests
             Constants.RefreshToken.JwtId,
             Constants.RefreshToken.CreationDateTime,
             Constants.RefreshToken.ExpirationDateTime,
+            Constants.RefreshToken.IssuedFrom,
             Constants.RefreshToken.Used,
             Constants.RefreshToken.Invalidated,
             Constants.RefreshToken.UserId
@@ -43,6 +44,7 @@ public sealed class RefreshTokenTests
             Constants.RefreshToken.JwtId,
             Constants.RefreshToken.CreationDateTime,
             Constants.RefreshToken.ExpirationDateTime,
+            Constants.RefreshToken.IssuedFrom,
             Constants.RefreshToken.Used,
             Constants.RefreshToken.Invalidated,
             Constants.RefreshToken.UserId
@@ -65,6 +67,7 @@ public sealed class RefreshTokenTests
             Constants.RefreshToken.JwtId,
             Constants.RefreshToken.CreationDateTime,
             Constants.RefreshToken.ExpirationDateTime,
+            Constants.RefreshToken.IssuedFrom,
             Constants.RefreshToken.Used,
             Constants.RefreshToken.Invalidated,
             Constants.RefreshToken.UserId
@@ -72,6 +75,29 @@ public sealed class RefreshTokenTests
 
         // Act & Assert
         Assert.Throws<InvalidTokenException>(cut);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public void RefreshToken_WhenPassedNullOrWhiteSpaceIssuedFrom_ShouldThrowUserIdIsNullException(string issuedFrom)
+    {
+        // Arrange
+        var cut = () => new RefreshToken(
+            Constants.RefreshToken.Id,
+            Constants.RefreshToken.Token,
+            Constants.RefreshToken.JwtId,
+            Constants.RefreshToken.CreationDateTime,
+            Constants.RefreshToken.ExpirationDateTime,
+            issuedFrom,
+            Constants.RefreshToken.Used,
+            Constants.RefreshToken.Invalidated,
+            Constants.RefreshToken.UserId
+        );
+
+        // Act & Assert
+        Assert.Throws<InvalidIpAddressException>(cut);
     }
 
     [Fact]
@@ -84,6 +110,7 @@ public sealed class RefreshTokenTests
             Constants.RefreshToken.JwtId,
             Constants.RefreshToken.CreationDateTime,
             Constants.RefreshToken.ExpirationDateTime,
+            Constants.RefreshToken.IssuedFrom,
             Constants.RefreshToken.Used,
             Constants.RefreshToken.Invalidated,
             null

--- a/tests/Domain.Unit.Tests/RefreshTokens/RefreshTokenTests.cs
+++ b/tests/Domain.Unit.Tests/RefreshTokens/RefreshTokenTests.cs
@@ -119,4 +119,57 @@ public sealed class RefreshTokenTests
         // Act & Assert
         Assert.Throws<UserIdIsNullException>(cut);
     }
+
+    [Fact]
+    public void RefreshToken_IsActive_ShouldReturnTrue()
+    {
+        // Arrange
+        var cut = new RefreshToken(
+            Constants.RefreshToken.Id,
+            Constants.RefreshToken.Token,
+            Constants.RefreshToken.JwtId,
+            Constants.RefreshToken.CreationDateTime,
+            Constants.RefreshToken.ExpirationDateTime,
+            Constants.RefreshToken.IssuedFrom,
+            Constants.RefreshToken.Used,
+            Constants.RefreshToken.Invalidated,
+            Constants.RefreshToken.UserId
+        );
+
+        // Act
+        bool result = cut.IsActive();
+
+        // Assert
+        result
+            .Should()
+            .BeTrue();
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    [InlineData(false, true)]
+    public void RefreshToken_IsActive_ShouldReturnFalse(bool used, bool invalidated)
+    {
+        // Arrange
+        var cut = new RefreshToken(
+            Constants.RefreshToken.Id,
+            Constants.RefreshToken.Token,
+            Constants.RefreshToken.JwtId,
+            Constants.RefreshToken.CreationDateTime,
+            Constants.RefreshToken.ExpirationDateTime,
+            Constants.RefreshToken.IssuedFrom,
+            used,
+            invalidated,
+            Constants.RefreshToken.UserId
+        );
+
+        // Act
+        bool result = cut.IsActive();
+
+        // Assert
+        result
+            .Should()
+            .BeFalse();
+    }
 }

--- a/tests/Domain.Unit.Tests/RefreshTokens/TestUtilities/Constants.RefreshToken.cs
+++ b/tests/Domain.Unit.Tests/RefreshTokens/TestUtilities/Constants.RefreshToken.cs
@@ -13,6 +13,7 @@ public static partial class Constants
         public static readonly Guid JwtId = new Guid(0, 0, 0, new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 });
         public static readonly DateTime CreationDateTime = DateTime.Now;
         public static readonly DateTime ExpirationDateTime = DateTime.Now.AddDays(1);
+        public const string IssuedFrom = "127.0.0.1";
         public const bool Used = false;
         public const bool Invalidated = false;
         public static readonly UserId UserId = new(new Guid(0, 0, 0, new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }));

--- a/tests/WebAPI.Unit.Tests/Identity/IdentityControllerTests.cs
+++ b/tests/WebAPI.Unit.Tests/Identity/IdentityControllerTests.cs
@@ -44,6 +44,8 @@ public sealed class IdentityControllerTests
             );
 
         _mockUserService = Substitute.For<IUserService>();
+        _mockUserService.IpAddress
+            .Returns("127.0.0.1");
 
         _cut = new IdentityController(
             _mockRegister,
@@ -178,6 +180,24 @@ public sealed class IdentityControllerTests
     }
 
     [Fact]
+    public async Task Login_WhenIpAddressNotPresent_ShouldThrowSourceAddressNotFoundException()
+    {
+        // Arrange
+        var request = new LoginRequest(
+            "test2@example.com",
+            "P@##w0rd1."
+        );
+
+        _mockUserService.IpAddress
+            .Returns("");
+
+        // Act & Assert
+        var result = await Assert.ThrowsAsync<SourceAddressNotFoundException>(
+            async () => await _cut.Login(request)
+        );
+    }
+
+    [Fact]
     public async Task Login_OnSuccess_ShouldReturn200StatusCode()
     {
         // Arrange
@@ -285,6 +305,24 @@ public sealed class IdentityControllerTests
         result
             .Should()
             .BeOfType<OkObjectResult>();
+    }
+
+    [Fact]
+    public async Task RefreshToken_WhenIpAddressNotPresent_ShouldThrowSourceAddressNotFoundException()
+    {
+        // Arrange
+        var request = new RefreshRequest(
+            "eyJHBn01.",
+            "M8Xy+-=="
+        );
+
+        _mockUserService.IpAddress
+            .Returns("");
+
+        // Act & Assert
+        var result = await Assert.ThrowsAsync<SourceAddressNotFoundException>(
+            async () => await _cut.Refresh(request)
+        );
     }
 
     [Fact]


### PR DESCRIPTION
### What?

This refactor consists from a few changes to login process:
- when user logs in, application saves refresh token in database along with IP address where the login was issued from,
- when user logs in again with valid credentials, new pair of `accessToken` and `refreshToken` is returned - allowing to have multiple auth session (this change with previous will transform in the future to "one-session-per-device"),
- when user refreshes the token, new token has property `RefreshedBy` - saving the `Id` of the used token,
- when someone tries to use already used or invalidated token, application invalidates all tokens in hierarchy that were created using passed refresh token - this can mean that someone has stolen users refresh token.

### Why?

For increasing the security and user experience from web api UI.

### How?

There were changes in controller and command handlers.
Added unit tests for new cases and removed all test cases that are no longer valid in case of application logic.

Related to #109 